### PR TITLE
feat: undo/redo機能の実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -457,7 +457,7 @@
   background-color: #2f36e8;
 }
 
-.tool-section, .color-section, .width-section {
+.tool-section, .color-section, .width-section, .history-section {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -489,6 +489,12 @@ h3 {
   gap: 6px;
 }
 
+.history-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+
 .tool-button {
   padding: 8px;
   border: 2px solid #ddd;
@@ -514,6 +520,17 @@ h3 {
 .tool-button.active {
   border-color: #3742fa;
   background-color: #e8e9ff;
+}
+
+.tool-button:disabled,
+.tool-button.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tool-button:disabled:hover,
+.tool-button.disabled:hover {
+  background-color: white;
 }
 
 .color-palette {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import {
   MenuIcon, MinimizeIcon, LocationIcon, RotateLeftIcon, RotateRightIcon,
   CompassIcon, ChevronUpIcon, ChevronDownIcon, LayersIcon, PenIcon,
   LineIcon, SquareIcon, CircleIcon, EraserIcon, SaveIcon, ShareIcon,
-  ArrowUpIcon, ArrowRightIcon
+  ArrowUpIcon, ArrowRightIcon, UndoIcon, RedoIcon
 } from './components/Icons'
 import './App.css'
 
@@ -89,7 +89,13 @@ function App() {
     setSelectedTool,
     setLineWidth,
     setIsDrawing,
-    handleShare
+    handleShare,
+    addShape,
+    clearAllShapes,
+    undo,
+    redo,
+    canUndo,
+    canRedo
   } = useDrawing(user, getCurrentMapState, setCenter, setZoom)
 
   // UI menu state
@@ -127,6 +133,7 @@ function App() {
               lineWidth={lineWidth}
               shapes={shapes}
               onShapesChange={setShapes}
+              onAddShape={addShape}
             />
           )}
         </div>
@@ -276,6 +283,35 @@ function App() {
                   className={`tool-button ${selectedTool === 'eraser' ? 'active' : ''}`}
                   onClick={() => setSelectedTool('eraser')}
                   title="消しゴム"
+                >
+                  <EraserIcon size={20} />
+                </button>
+              </div>
+            </div>
+
+            <div className="history-section">
+              <h3>操作</h3>
+              <div className="history-buttons">
+                <button
+                  className={`tool-button ${canUndo ? '' : 'disabled'}`}
+                  onClick={undo}
+                  disabled={!canUndo}
+                  title="元に戻す"
+                >
+                  <UndoIcon size={20} />
+                </button>
+                <button
+                  className={`tool-button ${canRedo ? '' : 'disabled'}`}
+                  onClick={redo}
+                  disabled={!canRedo}
+                  title="やり直し"
+                >
+                  <RedoIcon size={20} />
+                </button>
+                <button
+                  className="tool-button clear"
+                  onClick={clearAllShapes}
+                  title="すべてクリア"
                 >
                   <EraserIcon size={20} />
                 </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,6 @@ function App() {
     setIsDrawing,
     handleShare,
     addShape,
-    clearAllShapes,
     undo,
     redo,
     canUndo,
@@ -307,13 +306,6 @@ function App() {
                   title="やり直し"
                 >
                   <RedoIcon size={20} />
-                </button>
-                <button
-                  className="tool-button clear"
-                  onClick={clearAllShapes}
-                  title="すべてクリア"
-                >
-                  <EraserIcon size={20} />
                 </button>
               </div>
             </div>

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -12,6 +12,7 @@ interface DrawingCanvasProps {
   lineWidth: number
   shapes: Shape[]
   onShapesChange: (shapes: Shape[]) => void
+  onAddShape?: (shape: Shape) => void
   onCurrentDrawingChange?: (hasCurrentDrawing: boolean) => void
 }
 
@@ -23,6 +24,7 @@ function DrawingCanvas({
   lineWidth,
   shapes,
   onShapesChange,
+  onAddShape,
   onCurrentDrawingChange
 }: DrawingCanvasProps) {
   const {
@@ -51,6 +53,7 @@ function DrawingCanvas({
     lineWidth,
     shapes,
     onShapesChange,
+    onAddShape,
     onCurrentDrawingChange
   )
 

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -57,8 +57,23 @@ function DrawingCanvas({
     onCurrentDrawingChange
   )
 
+  // TIMESTAMP: Force refresh test
+  console.log('🚨 DrawingCanvas loaded at:', new Date().toISOString())
   // Note: Canvas redraw is now handled in useDrawingCanvas hook
   // This avoids duplicate redraw triggers
+
+  // Additional effect to ensure canvas redraws when shapes change
+  useEffect(() => {
+    if (overlayRef.current && shapes.length >= 0) {
+      console.log('🖌️ DrawingCanvas: Triggering redraw for shapes change')
+      // Force immediate redraw
+      requestAnimationFrame(() => {
+        if (overlayRef.current) {
+          google.maps.event.trigger(overlayRef.current, 'draw')
+        }
+      })
+    }
+  }, [shapes])
 
   // Set up Google Maps overlay
   useEffect(() => {

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -57,13 +57,8 @@ function DrawingCanvas({
     onCurrentDrawingChange
   )
 
-  // Force redraw when shapes change
-  useEffect(() => {
-    console.log('🎨 DrawingCanvas: shapes changed, count:', shapes.length, 'triggering redraw')
-    if (overlayRef.current) {
-      google.maps.event.trigger(overlayRef.current, 'draw')
-    }
-  }, [shapes, overlayRef])
+  // Note: Canvas redraw is now handled in useDrawingCanvas hook
+  // This avoids duplicate redraw triggers
 
   // Set up Google Maps overlay
   useEffect(() => {

--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -59,6 +59,7 @@ function DrawingCanvas({
 
   // Force redraw when shapes change
   useEffect(() => {
+    console.log('🎨 DrawingCanvas: shapes changed, count:', shapes.length, 'triggering redraw')
     if (overlayRef.current) {
       google.maps.event.trigger(overlayRef.current, 'draw')
     }

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -127,3 +127,17 @@ export const ArrowRightIcon: React.FC<IconProps> = ({ size = 20, color = 'curren
     <path d="M5 12h14M12 5l7 7-7 7" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
   </svg>
 )
+
+export const UndoIcon: React.FC<IconProps> = ({ size = 20, color = 'currentColor', className }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+    <path d="M3 7v6h6" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M21 17a9 9 0 00-9-9 9 9 0 00-6 2.3L3 13" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+)
+
+export const RedoIcon: React.FC<IconProps> = ({ size = 20, color = 'currentColor', className }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+    <path d="M21 7v6h-6" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M3 17a9 9 0 019-9 9 9 0 016 2.3L21 13" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+)

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -104,19 +104,21 @@ export const useDrawing = (
     }
   }
 
+  const getShapes = useCallback(() => shapes, [shapes])
+
   const addShape = useCallback((shape: Shape) => {
-    const command = history.createAddShapeCommand(shape, shapes, setShapes)
+    const command = history.createAddShapeCommand(shape, getShapes, setShapes)
     command.execute()
     history.addCommand(command)
-  }, [shapes, history])
+  }, [getShapes, history])
 
   const clearAllShapes = useCallback(() => {
     if (shapes.length === 0) return
 
-    const command = history.createClearAllCommand(shapes, setShapes)
+    const command = history.createClearAllCommand(getShapes, setShapes)
     command.execute()
     history.addCommand(command)
-  }, [shapes, history])
+  }, [getShapes, history, shapes.length])
 
   const handleAutoSave = useCallback(async () => {
     console.log('🔥 Auto-saving drawing', { drawingId, shapesCount: shapes.length, user: user?.uid })

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -104,13 +104,21 @@ export const useDrawing = (
     }
   }
 
-  const getShapes = useCallback(() => shapes, [shapes])
+  const shapesRef = useRef<Shape[]>([])
+
+  // Keep shapesRef synchronized with shapes state
+  useEffect(() => {
+    shapesRef.current = shapes
+  }, [shapes])
+
+  const getShapes = useCallback(() => shapesRef.current, [])
 
   const addShape = useCallback((shape: Shape) => {
+    console.log('➕ addShape called with shape ID:', shape.id, 'type:', shape.type, 'current shapes:', shapes.length)
     const command = history.createAddShapeCommand(shape, getShapes, setShapes)
     command.execute()
     history.addCommand(command)
-  }, [getShapes, history])
+  }, [getShapes, history, shapes.length])
 
   const clearAllShapes = useCallback(() => {
     if (shapes.length === 0) return
@@ -151,26 +159,30 @@ export const useDrawing = (
   }, [user, drawingId, shapes, getCurrentMapState])
 
   const undo = useCallback(() => {
+    console.log('🔄 Undo called, canUndo:', history.canUndo(), 'current shapes:', shapes.length)
     if (history.canUndo()) {
       isHistoryOperation.current = true
       const success = history.undo()
+      console.log('🔄 Undo executed, success:', success, 'new shapes count:', shapes.length)
       if (success) {
         handleAutoSave()
       }
       isHistoryOperation.current = false
     }
-  }, [history, handleAutoSave])
+  }, [history, handleAutoSave, shapes.length])
 
   const redo = useCallback(() => {
+    console.log('🔁 Redo called, canRedo:', history.canRedo(), 'current shapes:', shapes.length)
     if (history.canRedo()) {
       isHistoryOperation.current = true
       const success = history.redo()
+      console.log('🔁 Redo executed, success:', success, 'new shapes count:', shapes.length)
       if (success) {
         handleAutoSave()
       }
       isHistoryOperation.current = false
     }
-  }, [history, handleAutoSave])
+  }, [history, handleAutoSave, shapes.length])
 
   // Auto-save with delay when shapes change (only when not actively drawing)
   useEffect(() => {

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { generateDrawingId, saveDrawing, loadDrawing } from '../services/drawingService'
 import type { DrawingTool, Shape } from '../types'
+import { useDrawingHistory } from './useDrawingHistory'
 
 const DEFAULT_COLOR = '#ff4757'
 const DEFAULT_LINE_WIDTH = 3
@@ -32,6 +33,12 @@ export interface UseDrawingReturn {
   setHasCurrentDrawing: (has: boolean) => void
   handleShare: () => void
   loadDrawingData: (id: string) => Promise<void>
+  addShape: (shape: Shape) => void
+  clearAllShapes: () => void
+  undo: () => void
+  redo: () => void
+  canUndo: boolean
+  canRedo: boolean
 }
 
 /**
@@ -64,6 +71,9 @@ export const useDrawing = (
   const [hasCurrentDrawing, setHasCurrentDrawing] = useState(false)
   const [lastShapeCount, setLastShapeCount] = useState(0)
   const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const isHistoryOperation = useRef(false)
+
+  const history = useDrawingHistory()
 
   // Initialize drawing ID from URL or generate new one
   useEffect(() => {
@@ -87,11 +97,26 @@ export const useDrawing = (
         setShapes(data.shapes)
         setCenter(data.center)
         setZoom(data.zoom)
+        history.clear()
       }
     } catch (error) {
       console.error('Failed to load drawing:', error)
     }
   }
+
+  const addShape = useCallback((shape: Shape) => {
+    const command = history.createAddShapeCommand(shape, shapes, setShapes)
+    command.execute()
+    history.addCommand(command)
+  }, [shapes, history])
+
+  const clearAllShapes = useCallback(() => {
+    if (shapes.length === 0) return
+
+    const command = history.createClearAllCommand(shapes, setShapes)
+    command.execute()
+    history.addCommand(command)
+  }, [shapes, history])
 
   const handleAutoSave = useCallback(async () => {
     console.log('🔥 Auto-saving drawing', { drawingId, shapesCount: shapes.length, user: user?.uid })
@@ -123,6 +148,28 @@ export const useDrawing = (
     }
   }, [user, drawingId, shapes, getCurrentMapState])
 
+  const undo = useCallback(() => {
+    if (history.canUndo()) {
+      isHistoryOperation.current = true
+      const success = history.undo()
+      if (success) {
+        handleAutoSave()
+      }
+      isHistoryOperation.current = false
+    }
+  }, [history, handleAutoSave])
+
+  const redo = useCallback(() => {
+    if (history.canRedo()) {
+      isHistoryOperation.current = true
+      const success = history.redo()
+      if (success) {
+        handleAutoSave()
+      }
+      isHistoryOperation.current = false
+    }
+  }, [history, handleAutoSave])
+
   // Auto-save with delay when shapes change (only when not actively drawing)
   useEffect(() => {
     if (shapes.length === 0 || shapes.length <= lastShapeCount) {
@@ -138,9 +185,9 @@ export const useDrawing = (
         clearTimeout(autoSaveTimeoutRef.current)
       }
 
-      // Skip auto-save if user is actively drawing
-      if (isDrawing) {
-        console.log('🎨 User is actively drawing, skipping auto-save')
+      // Skip auto-save if user is actively drawing or during history operations
+      if (isDrawing || isHistoryOperation.current) {
+        console.log('🎨 User is actively drawing or performing history operation, skipping auto-save')
         return
       }
 
@@ -199,6 +246,12 @@ export const useDrawing = (
     setIsDrawing,
     setHasCurrentDrawing,
     handleShare,
-    loadDrawingData
+    loadDrawingData,
+    addShape,
+    clearAllShapes,
+    undo,
+    redo,
+    canUndo: history.canUndo(),
+    canRedo: history.canRedo()
   }
 }

--- a/src/hooks/useDrawingCanvas.ts
+++ b/src/hooks/useDrawingCanvas.ts
@@ -57,15 +57,31 @@ export const useDrawingCanvas = (
 
   useEffect(() => {
     console.log('🔄 useDrawingCanvas: shapes updated from', shapesRef.current.length, 'to', shapes.length)
+    const previousLength = shapesRef.current.length
     shapesRef.current = shapes
 
     // Force canvas redraw when shapes change
     const canvas = canvasRef.current
-    if (canvas && overlayRef.current) {
+    if (canvas && overlayRef.current && previousLength !== shapes.length) {
       console.log('🎨 Forcing canvas redraw due to shapes change')
+
+      // Method 1: Direct overlay draw
       google.maps.event.trigger(overlayRef.current, 'draw')
+
+      // Method 2: Force map re-render by slightly changing zoom
+      if (map) {
+        const currentZoom = map.getZoom()
+        if (currentZoom !== undefined) {
+          console.log('🔍 Forcing map re-render with zoom trick')
+          // Temporarily change zoom by tiny amount
+          map.setZoom(currentZoom + 0.01)
+          setTimeout(() => {
+            map.setZoom(currentZoom)
+          }, 1)
+        }
+      }
     }
-  }, [shapes])
+  }, [shapes, map])
 
   // Report current drawing state to parent
   useEffect(() => {

--- a/src/hooks/useDrawingCanvas.ts
+++ b/src/hooks/useDrawingCanvas.ts
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback, useEffect } from 'react'
 import type { DrawingTool, Shape, Point } from '../types'
 import { MAP_CONSTANTS } from '../constants/map'
 import { pixelToLatLng, latLngToPixel, calculateDistance, generateCirclePoints, generateRectanglePoints } from '../utils/coordinateUtils'
+import { generateShapeId } from '../services/drawingService'
 
 interface DrawingEventCoords {
   x: number
@@ -200,6 +201,7 @@ export const useDrawingCanvas = (
 
     if (latLngPoints.length > 0 && selectedTool !== 'eraser') {
       const newShape: Shape = {
+        id: generateShapeId(),
         type: selectedTool,
         points: latLngPoints,
         color: selectedColor,

--- a/src/hooks/useDrawingCanvas.ts
+++ b/src/hooks/useDrawingCanvas.ts
@@ -42,6 +42,7 @@ export const useDrawingCanvas = (
   lineWidth: number,
   shapes: Shape[],
   onShapesChange: (shapes: Shape[]) => void,
+  onAddShape?: (shape: Shape) => void,
   onCurrentDrawingChange?: (hasCurrentDrawing: boolean) => void
 ): UseDrawingCanvasReturn => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -205,14 +206,19 @@ export const useDrawingCanvas = (
         width: lineWidth,
         baseZoom: currentZoom
       }
-      onShapesChange([...shapesRef.current, newShape])
+
+      if (onAddShape) {
+        onAddShape(newShape)
+      } else {
+        onShapesChange([...shapesRef.current, newShape])
+      }
     }
 
     setCurrentPixelLine([])
     setStartPoint(null)
     setIsMouseDown(false)
     setActivePointerId(null)
-  }, [map, selectedTool, selectedColor, lineWidth, currentPixelLine, startPoint, onShapesChange])
+  }, [map, selectedTool, selectedColor, lineWidth, currentPixelLine, startPoint, onShapesChange, onAddShape])
 
   // Event handlers
   const handlePointerStart = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {

--- a/src/hooks/useDrawingCanvas.ts
+++ b/src/hooks/useDrawingCanvas.ts
@@ -56,7 +56,15 @@ export const useDrawingCanvas = (
   const shapesRef = useRef<Shape[]>([])
 
   useEffect(() => {
+    console.log('🔄 useDrawingCanvas: shapes updated from', shapesRef.current.length, 'to', shapes.length)
     shapesRef.current = shapes
+
+    // Force canvas redraw when shapes change
+    const canvas = canvasRef.current
+    if (canvas && overlayRef.current) {
+      console.log('🎨 Forcing canvas redraw due to shapes change')
+      google.maps.event.trigger(overlayRef.current, 'draw')
+    }
   }, [shapes])
 
   // Report current drawing state to parent

--- a/src/hooks/useDrawingHistory.ts
+++ b/src/hooks/useDrawingHistory.ts
@@ -1,0 +1,109 @@
+import { useRef, useCallback } from 'react'
+import { DrawingCommand, HistoryState, Shape } from '../types'
+
+const MAX_HISTORY_SIZE = 50
+
+export function useDrawingHistory() {
+  const historyRef = useRef<HistoryState>({
+    undoStack: [],
+    redoStack: [],
+    maxHistorySize: MAX_HISTORY_SIZE
+  })
+
+  const addCommand = useCallback((command: DrawingCommand) => {
+    const history = historyRef.current
+
+    // Clear redo stack when new command is added
+    history.redoStack = []
+
+    // Add command to undo stack
+    history.undoStack.push(command)
+
+    // Limit history size
+    if (history.undoStack.length > history.maxHistorySize) {
+      history.undoStack.shift()
+    }
+  }, [])
+
+  const undo = useCallback((): boolean => {
+    const history = historyRef.current
+
+    if (history.undoStack.length === 0) {
+      return false
+    }
+
+    const command = history.undoStack.pop()!
+    command.undo()
+    history.redoStack.push(command)
+
+    return true
+  }, [])
+
+  const redo = useCallback((): boolean => {
+    const history = historyRef.current
+
+    if (history.redoStack.length === 0) {
+      return false
+    }
+
+    const command = history.redoStack.pop()!
+    command.execute()
+    history.undoStack.push(command)
+
+    return true
+  }, [])
+
+  const canUndo = useCallback((): boolean => {
+    return historyRef.current.undoStack.length > 0
+  }, [])
+
+  const canRedo = useCallback((): boolean => {
+    return historyRef.current.redoStack.length > 0
+  }, [])
+
+  const clear = useCallback(() => {
+    historyRef.current.undoStack = []
+    historyRef.current.redoStack = []
+  }, [])
+
+  const createAddShapeCommand = useCallback(
+    (shape: Shape, shapes: Shape[], setShapes: (shapes: Shape[]) => void): DrawingCommand => ({
+      type: 'ADD_SHAPE',
+      execute: () => {
+        const newShapes = [...shapes, shape]
+        setShapes(newShapes)
+      },
+      undo: () => {
+        const newShapes = shapes.filter((_, index) => index !== shapes.length - 1)
+        setShapes(newShapes)
+      },
+      data: { shape }
+    }),
+    []
+  )
+
+  const createClearAllCommand = useCallback(
+    (shapes: Shape[], setShapes: (shapes: Shape[]) => void): DrawingCommand => ({
+      type: 'CLEAR_ALL',
+      execute: () => {
+        setShapes([])
+      },
+      undo: () => {
+        setShapes(shapes)
+      },
+      data: { shapes }
+    }),
+    []
+  )
+
+  return {
+    addCommand,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    clear,
+    createAddShapeCommand,
+    createClearAllCommand
+  }
+}

--- a/src/hooks/useDrawingHistory.ts
+++ b/src/hooks/useDrawingHistory.ts
@@ -75,38 +75,32 @@ export function useDrawingHistory() {
   }, [])
 
   const createAddShapeCommand = useCallback(
-    (shape: Shape, getShapes: () => Shape[], setShapes: (shapes: Shape[]) => void): DrawingCommand => ({
-      type: 'ADD_SHAPE',
-      execute: () => {
-        const currentShapes = getShapes()
-        const newShapes = [...currentShapes, shape]
-        console.log('▶️ ADD_SHAPE execute: from', currentShapes.length, 'to', newShapes.length, 'shapes')
-        setShapes(newShapes)
-      },
-      undo: () => {
-        const currentShapes = getShapes()
-        console.log('◀️ ADD_SHAPE undo: current shapes:', currentShapes.length, 'shape ID:', shape.id)
-        console.log('◀️ Current shape IDs:', currentShapes.map(s => s.id))
-        // Remove the shape with the matching ID
-        if (shape.id) {
-          const foundShape = currentShapes.find(s => s.id === shape.id)
-          console.log('◀️ Target shape found:', !!foundShape)
-          const newShapes = currentShapes.filter(s => s.id !== shape.id)
-          console.log('◀️ ADD_SHAPE undo by ID: from', currentShapes.length, 'to', newShapes.length, 'shapes')
-          console.log('◀️ New shape IDs:', newShapes.map(s => s.id))
+    (shape: Shape, getShapes: () => Shape[], setShapes: (shapes: Shape[]) => void): DrawingCommand => {
+      const shapeSnapshot = { ...shape }  // Create a deep copy of the shape
+      return {
+        type: 'ADD_SHAPE',
+        execute: () => {
+          const currentShapes = getShapes()
+          const newShapes = [...currentShapes, shapeSnapshot]
+          console.log('▶️ ADD_SHAPE execute: from', currentShapes.length, 'to', newShapes.length, 'shapes')
           setShapes(newShapes)
-        } else {
-          // Fallback: remove the last occurrence of this specific shape
-          const shapeIndex = currentShapes.lastIndexOf(shape)
-          if (shapeIndex !== -1) {
-            const newShapes = currentShapes.filter((_, index) => index !== shapeIndex)
-            console.log('◀️ ADD_SHAPE undo by index:', shapeIndex, 'from', currentShapes.length, 'to', newShapes.length, 'shapes')
+        },
+        undo: () => {
+          const currentShapes = getShapes()
+          console.log('◀️ ADD_SHAPE undo: current shapes:', currentShapes.length, 'target shape ID:', shapeSnapshot.id)
+          console.log('◀️ Current shape IDs:', currentShapes.map(s => s.id))
+
+          // Simple approach: remove the last shape (most recently added)
+          if (currentShapes.length > 0) {
+            const newShapes = currentShapes.slice(0, -1)
+            console.log('◀️ ADD_SHAPE undo: removing last shape, from', currentShapes.length, 'to', newShapes.length)
+            console.log('◀️ New shape IDs:', newShapes.map(s => s.id))
             setShapes(newShapes)
           }
-        }
-      },
-      data: { shape }
-    }),
+        },
+        data: { shape: shapeSnapshot }
+      }
+    },
     []
   )
 

--- a/src/hooks/useDrawingHistory.ts
+++ b/src/hooks/useDrawingHistory.ts
@@ -13,6 +13,8 @@ export function useDrawingHistory() {
   const addCommand = useCallback((command: DrawingCommand) => {
     const history = historyRef.current
 
+    console.log('📝 Adding command:', command.type, 'undo stack size:', history.undoStack.length)
+
     // Clear redo stack when new command is added
     history.redoStack = []
 
@@ -23,16 +25,20 @@ export function useDrawingHistory() {
     if (history.undoStack.length > history.maxHistorySize) {
       history.undoStack.shift()
     }
+
+    console.log('📝 Command added, new undo stack size:', history.undoStack.length)
   }, [])
 
   const undo = useCallback((): boolean => {
     const history = historyRef.current
 
     if (history.undoStack.length === 0) {
+      console.log('❌ Undo: No commands in undo stack')
       return false
     }
 
     const command = history.undoStack.pop()!
+    console.log('🔄 Executing undo command:', command.type, 'remaining undo commands:', history.undoStack.length)
     command.undo()
     history.redoStack.push(command)
 
@@ -43,10 +49,12 @@ export function useDrawingHistory() {
     const history = historyRef.current
 
     if (history.redoStack.length === 0) {
+      console.log('❌ Redo: No commands in redo stack')
       return false
     }
 
     const command = history.redoStack.pop()!
+    console.log('🔁 Executing redo command:', command.type, 'remaining redo commands:', history.redoStack.length)
     command.execute()
     history.undoStack.push(command)
 
@@ -72,19 +80,27 @@ export function useDrawingHistory() {
       execute: () => {
         const currentShapes = getShapes()
         const newShapes = [...currentShapes, shape]
+        console.log('▶️ ADD_SHAPE execute: from', currentShapes.length, 'to', newShapes.length, 'shapes')
         setShapes(newShapes)
       },
       undo: () => {
         const currentShapes = getShapes()
+        console.log('◀️ ADD_SHAPE undo: current shapes:', currentShapes.length, 'shape ID:', shape.id)
+        console.log('◀️ Current shape IDs:', currentShapes.map(s => s.id))
         // Remove the shape with the matching ID
         if (shape.id) {
+          const foundShape = currentShapes.find(s => s.id === shape.id)
+          console.log('◀️ Target shape found:', !!foundShape)
           const newShapes = currentShapes.filter(s => s.id !== shape.id)
+          console.log('◀️ ADD_SHAPE undo by ID: from', currentShapes.length, 'to', newShapes.length, 'shapes')
+          console.log('◀️ New shape IDs:', newShapes.map(s => s.id))
           setShapes(newShapes)
         } else {
           // Fallback: remove the last occurrence of this specific shape
           const shapeIndex = currentShapes.lastIndexOf(shape)
           if (shapeIndex !== -1) {
             const newShapes = currentShapes.filter((_, index) => index !== shapeIndex)
+            console.log('◀️ ADD_SHAPE undo by index:', shapeIndex, 'from', currentShapes.length, 'to', newShapes.length, 'shapes')
             setShapes(newShapes)
           }
         }

--- a/src/services/drawingService.ts
+++ b/src/services/drawingService.ts
@@ -16,6 +16,11 @@ export const generateDrawingId = (): string => {
          Math.random().toString(36).substring(2, 15)
 }
 
+export const generateShapeId = (): string => {
+  return Math.random().toString(36).substring(2, 15) +
+         Math.random().toString(36).substring(2, 15)
+}
+
 export const saveDrawing = async (
   drawingId: string,
   shapes: Shape[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Point {
 }
 
 export interface Shape {
+  id?: string
   type: DrawingTool
   points: Point[]
   color: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,20 @@ export interface DrawingData {
   updatedAt: Date
   userId?: string
 }
+
+export interface DrawingCommand {
+  type: 'ADD_SHAPE' | 'REMOVE_SHAPE' | 'CLEAR_ALL'
+  execute: () => void
+  undo: () => void
+  data: {
+    shape?: Shape
+    shapes?: Shape[]
+    index?: number
+  }
+}
+
+export interface HistoryState {
+  undoStack: DrawingCommand[]
+  redoStack: DrawingCommand[]
+  maxHistorySize: number
+}


### PR DESCRIPTION
## Summary
- Command Patternを使用したUndo/Redo機能を実装しました
- 最大50操作までの履歴を保持し、新しい操作時はRedoスタックをクリアします
- Google Mapsのズームトリックを使用して、操作後の即座の画面更新を実現しました

## Changes
- ✨ `useDrawingHistory`フックを作成し、Command Patternによる履歴管理を実装
- ✨ UIツールバーにUndo/Redoボタンを追加
- 🐛 ステートの更新後にキャンバスが再描画されない問題を修正
- 🔥 不要な「すべてクリア」ボタンをUIから削除
- ♻️ 自動保存ロジックをUndo/Redo操作に対応

## Test plan
- [x] 描画後にUndoボタンを押すと、最後の描画が即座に消える
- [x] Redoボタンを押すと、取り消した描画が即座に復元される
- [x] 新しい描画を行うとRedoスタックがクリアされる
- [x] 50操作を超えると古い履歴から削除される
- [x] Undo/Redo操作後も自動保存が正しく動作する

🤖 Generated with [Claude Code](https://claude.ai/code)