### PR TITLE
chore: デバッグログの削除

### DIFF
--- a/src/components/DrawingCanvas.tsx
+++ b/src/components/DrawingCanvas.tsx
@@ -57,15 +57,12 @@ function DrawingCanvas({
     onCurrentDrawingChange
   )
 
-  // TIMESTAMP: Force refresh test
-  console.log('🚨 DrawingCanvas loaded at:', new Date().toISOString())
   // Note: Canvas redraw is now handled in useDrawingCanvas hook
   // This avoids duplicate redraw triggers
 
   // Additional effect to ensure canvas redraws when shapes change
   useEffect(() => {
     if (overlayRef.current && shapes.length >= 0) {
-      console.log('🖌️ DrawingCanvas: Triggering redraw for shapes change')
       // Force immediate redraw
       requestAnimationFrame(() => {
         if (overlayRef.current) {

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -114,7 +114,6 @@ export const useDrawing = (
   const getShapes = useCallback(() => shapesRef.current, [])
 
   const addShape = useCallback((shape: Shape) => {
-    console.log('➕ addShape called with shape ID:', shape.id, 'type:', shape.type, 'current shapes:', shapes.length)
     const command = history.createAddShapeCommand(shape, getShapes, setShapes)
     command.execute()
     history.addCommand(command)
@@ -129,10 +128,7 @@ export const useDrawing = (
   }, [getShapes, history, shapes.length])
 
   const handleAutoSave = useCallback(async () => {
-    console.log('🔥 Auto-saving drawing', { drawingId, shapesCount: shapes.length, user: user?.uid })
-
     if (!user) {
-      console.log('⚠️ User not authenticated, skipping auto-save')
       return
     }
 
@@ -142,7 +138,6 @@ export const useDrawing = (
     }
 
     if (shapes.length === 0) {
-      console.warn('⚠️ No shapes to save')
       return
     }
 
@@ -150,7 +145,6 @@ export const useDrawing = (
     try {
       const currentMapState = getCurrentMapState()
       await saveDrawing(drawingId, shapes, currentMapState.center, currentMapState.zoom)
-      console.log('✅ Drawing auto-saved successfully')
     } catch (error) {
       console.error('Failed to auto-save drawing:', error)
     } finally {
@@ -159,30 +153,26 @@ export const useDrawing = (
   }, [user, drawingId, shapes, getCurrentMapState])
 
   const undo = useCallback(() => {
-    console.log('🔄 Undo called, canUndo:', history.canUndo(), 'current shapes:', shapes.length)
     if (history.canUndo()) {
       isHistoryOperation.current = true
       const success = history.undo()
-      console.log('🔄 Undo executed, success:', success, 'new shapes count:', shapes.length)
       if (success) {
         handleAutoSave()
       }
       isHistoryOperation.current = false
     }
-  }, [history, handleAutoSave, shapes.length])
+  }, [history, handleAutoSave])
 
   const redo = useCallback(() => {
-    console.log('🔁 Redo called, canRedo:', history.canRedo(), 'current shapes:', shapes.length)
     if (history.canRedo()) {
       isHistoryOperation.current = true
       const success = history.redo()
-      console.log('🔁 Redo executed, success:', success, 'new shapes count:', shapes.length)
       if (success) {
         handleAutoSave()
       }
       isHistoryOperation.current = false
     }
-  }, [history, handleAutoSave, shapes.length])
+  }, [history, handleAutoSave])
 
   // Auto-save with delay when shapes change (only when not actively drawing)
   useEffect(() => {
@@ -201,13 +191,11 @@ export const useDrawing = (
 
       // Skip auto-save if user is actively drawing or during history operations
       if (isDrawing || isHistoryOperation.current) {
-        console.log('🎨 User is actively drawing or performing history operation, skipping auto-save')
         return
       }
 
       // Set new timeout for delayed auto-save
       autoSaveTimeoutRef.current = setTimeout(() => {
-        console.log('⏰ Auto-save delay completed, executing save...')
         handleAutoSave()
       }, AUTO_SAVE_DELAY)
     }
@@ -223,7 +211,6 @@ export const useDrawing = (
 
       // Trigger delayed auto-save when drawing ends
       autoSaveTimeoutRef.current = setTimeout(() => {
-        console.log('🏁 Drawing ended, executing delayed auto-save...')
         handleAutoSave()
       }, AUTO_SAVE_DELAY)
     }

--- a/src/hooks/useDrawingCanvas.ts
+++ b/src/hooks/useDrawingCanvas.ts
@@ -56,15 +56,12 @@ export const useDrawingCanvas = (
   const shapesRef = useRef<Shape[]>([])
 
   useEffect(() => {
-    console.log('🔄 useDrawingCanvas: shapes updated from', shapesRef.current.length, 'to', shapes.length)
     const previousLength = shapesRef.current.length
     shapesRef.current = shapes
 
     // Force canvas redraw when shapes change
     const canvas = canvasRef.current
     if (canvas && overlayRef.current && previousLength !== shapes.length) {
-      console.log('🎨 Forcing canvas redraw due to shapes change')
-
       // Method 1: Direct overlay draw
       google.maps.event.trigger(overlayRef.current, 'draw')
 
@@ -72,7 +69,6 @@ export const useDrawingCanvas = (
       if (map) {
         const currentZoom = map.getZoom()
         if (currentZoom !== undefined) {
-          console.log('🔍 Forcing map re-render with zoom trick')
           // Temporarily change zoom by tiny amount
           map.setZoom(currentZoom + 0.01)
           setTimeout(() => {

--- a/src/hooks/useDrawingHistory.ts
+++ b/src/hooks/useDrawingHistory.ts
@@ -13,8 +13,6 @@ export function useDrawingHistory() {
   const addCommand = useCallback((command: DrawingCommand) => {
     const history = historyRef.current
 
-    console.log('📝 Adding command:', command.type, 'undo stack size:', history.undoStack.length)
-
     // Clear redo stack when new command is added
     history.redoStack = []
 
@@ -26,19 +24,16 @@ export function useDrawingHistory() {
       history.undoStack.shift()
     }
 
-    console.log('📝 Command added, new undo stack size:', history.undoStack.length)
   }, [])
 
   const undo = useCallback((): boolean => {
     const history = historyRef.current
 
     if (history.undoStack.length === 0) {
-      console.log('❌ Undo: No commands in undo stack')
       return false
     }
 
     const command = history.undoStack.pop()!
-    console.log('🔄 Executing undo command:', command.type, 'remaining undo commands:', history.undoStack.length)
     command.undo()
     history.redoStack.push(command)
 
@@ -49,12 +44,10 @@ export function useDrawingHistory() {
     const history = historyRef.current
 
     if (history.redoStack.length === 0) {
-      console.log('❌ Redo: No commands in redo stack')
       return false
     }
 
     const command = history.redoStack.pop()!
-    console.log('🔁 Executing redo command:', command.type, 'remaining redo commands:', history.redoStack.length)
     command.execute()
     history.undoStack.push(command)
 
@@ -82,19 +75,14 @@ export function useDrawingHistory() {
         execute: () => {
           const currentShapes = getShapes()
           const newShapes = [...currentShapes, shapeSnapshot]
-          console.log('▶️ ADD_SHAPE execute: from', currentShapes.length, 'to', newShapes.length, 'shapes')
           setShapes(newShapes)
         },
         undo: () => {
           const currentShapes = getShapes()
-          console.log('◀️ ADD_SHAPE undo: current shapes:', currentShapes.length, 'target shape ID:', shapeSnapshot.id)
-          console.log('◀️ Current shape IDs:', currentShapes.map(s => s.id))
 
           // Simple approach: remove the last shape (most recently added)
           if (currentShapes.length > 0) {
             const newShapes = currentShapes.slice(0, -1)
-            console.log('◀️ ADD_SHAPE undo: removing last shape, from', currentShapes.length, 'to', newShapes.length)
-            console.log('◀️ New shape IDs:', newShapes.map(s => s.id))
             setShapes(newShapes)
           }
         },

--- a/src/services/drawingService.ts
+++ b/src/services/drawingService.ts
@@ -27,17 +27,8 @@ export const saveDrawing = async (
   center: { lat: number; lng: number },
   zoom: number
 ): Promise<void> => {
-  console.log('🔥 Starting save operation:', {
-    drawingId,
-    shapesCount: shapes.length,
-    center,
-    zoom
-  })
-
   try {
     const drawingRef = doc(db, COLLECTION_NAME, drawingId)
-    console.log('🔥 Document reference created:', drawingRef.path)
-
     const drawingData = {
       shapes,
       center,
@@ -45,20 +36,15 @@ export const saveDrawing = async (
       updatedAt: serverTimestamp()
     }
 
-    console.log('🔥 Checking existing document...')
     const existingDoc = await getDoc(drawingRef)
 
     if (existingDoc.exists()) {
-      console.log('🔥 Updating existing document')
       await updateDoc(drawingRef, drawingData)
-      console.log('✅ Document updated successfully')
     } else {
-      console.log('🔥 Creating new document')
       await setDoc(drawingRef, {
         ...drawingData,
         createdAt: serverTimestamp()
       })
-      console.log('✅ Document created successfully')
     }
   } catch (error) {
     console.error('❌ Save error:', error)
@@ -67,19 +53,12 @@ export const saveDrawing = async (
 }
 
 export const loadDrawing = async (drawingId: string): Promise<DrawingData | null> => {
-  console.log('🔥 Loading drawing:', drawingId)
-
   try {
     const drawingRef = doc(db, COLLECTION_NAME, drawingId)
-    console.log('🔥 Document reference created:', drawingRef.path)
-
     const drawingSnap = await getDoc(drawingRef)
-    console.log('🔥 Document exists:', drawingSnap.exists())
 
     if (drawingSnap.exists()) {
       const data = drawingSnap.data()
-      console.log('🔥 Document data:', data)
-
       return {
         id: drawingId,
         shapes: data.shapes || [],
@@ -91,7 +70,6 @@ export const loadDrawing = async (drawingId: string): Promise<DrawingData | null
       }
     }
 
-    console.log('⚠️ Document not found')
     return null
   } catch (error) {
     console.error('❌ Load error:', error)


### PR DESCRIPTION
## Summary
Undo/Redo機能実装時に追加されたデバッグ用のconsole.logを削除し、本番環境に必要なエラーログのみを残します。

## Changes
- 🔇 開発時のデバッグ用console.logを削除
- ✅ 本番環境で必要なエラーログは保持

## 削除したログ
- Undo/Redo操作の詳細なトレースログ
- コマンド追加のログ  
- キャンバス再描画のログ
- 保存操作の詳細なログ
- タイムスタンプ付きのデバッグログ

## 残したログ（本番環境で必要）
- `console.error()` - エラーの追跡に必要
- Failed to load/save drawing
- No drawing ID
- Save/Load error

🤖 Generated with [Claude Code](https://claude.ai/code)