### PR TITLE
feat: implement tile-based bitmap drawing with Firebase Storage

### DIFF
--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/firebase.json
+++ b/firebase.json
@@ -46,9 +46,16 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "emulators": {
     "firestore": {
       "port": 8080,
+      "host": "0.0.0.0"
+    },
+    "storage": {
+      "port": 9199,
       "host": "0.0.0.0"
     },
     "ui": {

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,14 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    // drawings コレクション：読み取りは全員、書き込みは認証済みユーザーのみ
+    // drawings コレクション（v1ベクター形式）：読み取りは全員、書き込みは認証済みユーザーのみ
     match /drawings/{documentId} {
+      allow read: if true;                    // 誰でも描画を見ることができる
+      allow write: if request.auth != null;  // 認証済みユーザーのみ編集可能
+    }
+
+    // drawings_v2 コレクション（v2タイル形式）：読み取りは全員、書き込みは認証済みユーザーのみ
+    match /drawings_v2/{documentId} {
       allow read: if true;                    // 誰でも描画を見ることができる
       allow write: if request.auth != null;  // 認証済みユーザーのみ編集可能
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 import { GoogleMap, LoadScript } from '@react-google-maps/api'
-import DrawingCanvas from './components/DrawingCanvas'
+import DrawingCanvasV2 from './components/DrawingCanvasV2'
 import LayerPanel from './components/LayerPanel'
 import { useAuthManager } from './hooks/useAuthManager'
 import { useMap } from './hooks/useMap'
-import { useDrawing } from './hooks/useDrawing'
+import { useDrawingV2 } from './hooks/useDrawingV2'
 import { useMenu } from './hooks/useMenu'
 import { DRAWING_COLORS } from './constants/drawing'
 import { MAP_CONTAINER_STYLE, LIBRARIES } from './constants/googleMaps'
@@ -73,28 +73,27 @@ function App() {
     resetMapRotation,
     adjustTilt,
     resetTilt,
-    getCurrentMapState,
-    setCenter,
-    setZoom
+    getCurrentMapState
   } = useMap()
 
-  // Drawing state and smart auto-save
+  // Drawing state and smart auto-save (V2 - tile-based)
   const {
-    shapes,
     layers,
     activeLayerId,
+    baseZoom,
     selectedColor,
     selectedTool,
     lineWidth,
     isDrawing,
     isSaving,
-    setShapes,
+    tileCache,
     setSelectedColor,
     setSelectedTool,
     setLineWidth,
     setIsDrawing,
+    setHasCurrentDrawing,
     handleShare,
-    addShape,
+    onDrawingComplete,
     undo,
     redo,
     canUndo,
@@ -106,7 +105,7 @@ function App() {
     reorderLayers,
     toggleLayerVisibility,
     toggleLayerLock
-  } = useDrawing(user, getCurrentMapState, setCenter, setZoom)
+  } = useDrawingV2(user, getCurrentMapState)
 
   // UI menu state
   const {
@@ -138,17 +137,18 @@ function App() {
             options={MAP_OPTIONS}
           />
           {map && (
-            <DrawingCanvas
+            <DrawingCanvasV2
               map={map}
               isDrawing={isDrawing}
-              onDrawingChange={setIsDrawing}
               selectedColor={selectedColor}
               selectedTool={selectedTool}
               lineWidth={lineWidth}
-              shapes={shapes}
               layers={layers}
-              onShapesChange={setShapes}
-              onAddShape={addShape}
+              activeLayerId={activeLayerId}
+              baseZoom={baseZoom}
+              tileCache={tileCache}
+              onDrawingComplete={onDrawingComplete}
+              onCurrentDrawingChange={setHasCurrentDrawing}
             />
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { DRAWING_COLORS } from './constants/drawing'
 import { MAP_CONTAINER_STYLE, LIBRARIES } from './constants/googleMaps'
 import {
   MenuIcon, MinimizeIcon, LocationIcon, RotateLeftIcon, RotateRightIcon,
-  CompassIcon, ChevronUpIcon, ChevronDownIcon, LayersIcon, PenIcon, HandIcon,
+  CompassIcon, LayersIcon, PenIcon, HandIcon,
   LineIcon, SquareIcon, CircleIcon, EraserIcon, SaveIcon, ShareIcon,
   ArrowUpIcon, ArrowRightIcon, UndoIcon, RedoIcon
 } from './components/Icons'
@@ -42,7 +42,7 @@ const MAP_OPTIONS: google.maps.MapOptions = {
   tilt: 0,
   heading: 0,
   headingInteractionEnabled: true,
-  tiltInteractionEnabled: true,
+  tiltInteractionEnabled: false,  // 傾き無効化
 }
 
 /**
@@ -71,8 +71,6 @@ function App() {
     handleLocateMe,
     rotateMap,
     resetMapRotation,
-    adjustTilt,
-    resetTilt,
     getCurrentMapState
   } = useMap()
 
@@ -217,29 +215,6 @@ function App() {
                       className="action-button reset-rotation"
                       onClick={resetMapRotation}
                       title="回転をリセット"
-                    >
-                      <CompassIcon size={16} />
-                    </button>
-                  </div>
-                  <div className="tilt-controls">
-                    <button
-                      className="action-button tilt-up"
-                      onClick={() => adjustTilt(15)}
-                      title="チルトアップ（15度）"
-                    >
-                      <ChevronUpIcon size={16} />
-                    </button>
-                    <button
-                      className="action-button tilt-down"
-                      onClick={() => adjustTilt(-15)}
-                      title="チルトダウン（15度）"
-                    >
-                      <ChevronDownIcon size={16} />
-                    </button>
-                    <button
-                      className="action-button reset-tilt"
-                      onClick={resetTilt}
-                      title="チルトリセット（平面表示）"
                     >
                       <CompassIcon size={16} />
                     </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,6 +234,11 @@ function App() {
                   保存中...
                 </div>
               )}
+              {isDrawing && (
+                <div className="zoom-indicator">
+                  baseZoom: {baseZoom}
+                </div>
+              )}
             </div>
 
             {isDrawing && (

--- a/src/components/DrawingCanvasV2.tsx
+++ b/src/components/DrawingCanvasV2.tsx
@@ -1,0 +1,314 @@
+import { useEffect } from 'react'
+import type { DrawingTool, LayerV2 } from '../types'
+import { useDrawingCanvasV2 } from '../hooks/useDrawingCanvasV2'
+import { getVisibleTiles, tileCoordToPixel } from '../services/tileService'
+import type { TileCacheManager } from '../hooks/useTileCache'
+import './DrawingCanvas.css'
+
+interface DrawingCanvasV2Props {
+  map: google.maps.Map
+  isDrawing: boolean
+  selectedColor: string
+  selectedTool: DrawingTool
+  lineWidth: number
+  layers: LayerV2[]
+  activeLayerId: string | null
+  baseZoom: number
+  tileCache: TileCacheManager
+  onDrawingComplete?: () => void
+  onCurrentDrawingChange?: (hasCurrentDrawing: boolean) => void
+}
+
+const TILE_SIZE_PX = 256
+
+function DrawingCanvasV2({
+  map,
+  isDrawing,
+  selectedColor,
+  selectedTool,
+  lineWidth,
+  layers,
+  activeLayerId,
+  baseZoom,
+  tileCache,
+  onDrawingComplete,
+  onCurrentDrawingChange
+}: DrawingCanvasV2Props) {
+  const {
+    canvasRef,
+    overlayRef,
+    isMouseDown,
+    currentPixelLine,
+    startPoint,
+    hoverPoint,
+    handlePointerStart,
+    handlePointerMove,
+    handlePointerEnd,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave
+  } = useDrawingCanvasV2(
+    map,
+    isDrawing,
+    selectedTool,
+    selectedColor,
+    lineWidth,
+    activeLayerId,
+    tileCache,
+    onDrawingComplete,
+    onCurrentDrawingChange
+  )
+
+  // Set up Google Maps overlay
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !map) return
+
+    class TileDrawingOverlay extends google.maps.OverlayView {
+      canvas: HTMLCanvasElement
+
+      constructor(canvas: HTMLCanvasElement) {
+        super()
+        this.canvas = canvas
+      }
+
+      onAdd() {}
+
+      draw() {
+        const projection = this.getProjection()
+        if (!projection) return
+
+        const ctx = this.canvas.getContext('2d')
+        if (!ctx) return
+
+        const mapDiv = map.getDiv()
+        this.canvas.width = mapDiv.offsetWidth
+        this.canvas.height = mapDiv.offsetHeight
+
+        ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
+
+        // Get map bounds and zoom
+        const bounds = map.getBounds()
+        const currentZoom = map.getZoom()
+        if (!bounds || currentZoom === undefined) return
+
+        const ne = bounds.getNorthEast()
+        const sw = bounds.getSouthWest()
+        const mapBounds = {
+          north: ne.lat(),
+          south: sw.lat(),
+          east: ne.lng(),
+          west: sw.lng(),
+        }
+        const mapSize = {
+          width: this.canvas.width,
+          height: this.canvas.height,
+        }
+
+        // Get visible tiles at base zoom level
+        const visibleTiles = getVisibleTiles(mapBounds, baseZoom)
+
+        // Get visible layers sorted by order (bottom to top)
+        const visibleLayers = layers
+          .filter(layer => layer.visible)
+          .sort((a, b) => a.order - b.order)
+
+        // Draw tiles for each layer
+        visibleLayers.forEach(layer => {
+          ctx.save()
+          ctx.globalAlpha = layer.opacity
+
+          visibleTiles.forEach(tileCoord => {
+            // Check if we have this tile in cache or in layer's tiles
+            if (tileCache.hasTile(layer.id, tileCoord)) {
+              const tileCanvas = tileCache.getTileCanvas(layer.id, tileCoord)
+
+              // Calculate tile position on screen
+              const tilePixel = tileCoordToPixel(tileCoord, mapBounds, mapSize)
+
+              // Calculate tile size on screen based on zoom
+              const totalTiles = Math.pow(2, baseZoom)
+              const worldWidth = mapSize.width / ((mapBounds.east - mapBounds.west) / 360)
+              const tileScreenSize = (worldWidth / totalTiles)
+
+              // Draw the tile
+              ctx.drawImage(
+                tileCanvas,
+                0, 0, TILE_SIZE_PX, TILE_SIZE_PX,
+                tilePixel.x, tilePixel.y, tileScreenSize, tileScreenSize
+              )
+            }
+          })
+
+          ctx.restore()
+        })
+
+        // Draw current shape being drawn (preview)
+        if (startPoint && currentPixelLine.length > 0) {
+          ctx.strokeStyle = selectedColor
+          ctx.lineWidth = lineWidth
+          ctx.lineCap = 'round'
+          ctx.lineJoin = 'round'
+
+          if (selectedTool === 'pen' && currentPixelLine.length > 1) {
+            // Draw each segment with its own line width based on pressure
+            for (let i = 0; i < currentPixelLine.length - 1; i++) {
+              const point = currentPixelLine[i]
+              const nextPoint = currentPixelLine[i + 1]
+
+              ctx.beginPath()
+
+              // Apply pressure-based line width
+              const pressure = Math.max(0.1, Math.min(1.0, nextPoint.pressure || 0.5))
+              const dynamicWidth = lineWidth * (0.3 + pressure * 0.7)
+              ctx.lineWidth = dynamicWidth
+
+              ctx.moveTo(point.x, point.y)
+              ctx.lineTo(nextPoint.x, nextPoint.y)
+              ctx.stroke()
+            }
+          } else if (selectedTool === 'line') {
+            ctx.beginPath()
+            ctx.moveTo(startPoint.x, startPoint.y)
+            ctx.lineTo(
+              currentPixelLine[currentPixelLine.length - 1].x,
+              currentPixelLine[currentPixelLine.length - 1].y
+            )
+            ctx.stroke()
+          } else if (selectedTool === 'rectangle') {
+            const current = currentPixelLine[currentPixelLine.length - 1]
+            ctx.beginPath()
+            ctx.rect(
+              startPoint.x,
+              startPoint.y,
+              current.x - startPoint.x,
+              current.y - startPoint.y
+            )
+            ctx.stroke()
+          } else if (selectedTool === 'circle') {
+            const current = currentPixelLine[currentPixelLine.length - 1]
+            const radiusX = Math.abs(current.x - startPoint.x) / 2
+            const radiusY = Math.abs(current.y - startPoint.y) / 2
+            const centerX = (startPoint.x + current.x) / 2
+            const centerY = (startPoint.y + current.y) / 2
+
+            ctx.beginPath()
+            ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, 2 * Math.PI)
+            ctx.stroke()
+          } else if (selectedTool === 'eraser' && currentPixelLine.length > 0) {
+            // Draw eraser preview circle
+            const eraserRadius = lineWidth * 6
+            const lastPoint = currentPixelLine[currentPixelLine.length - 1]
+
+            ctx.strokeStyle = 'rgba(0, 0, 0, 0.5)'
+            ctx.lineWidth = 2
+            ctx.beginPath()
+            ctx.arc(lastPoint.x, lastPoint.y, eraserRadius, 0, 2 * Math.PI)
+            ctx.stroke()
+
+            ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)'
+            ctx.lineWidth = 1
+            ctx.beginPath()
+            ctx.arc(lastPoint.x, lastPoint.y, eraserRadius - 1, 0, 2 * Math.PI)
+            ctx.stroke()
+          }
+        }
+
+        // Draw hover cursor for eraser when not drawing
+        if (!isMouseDown && selectedTool === 'eraser' && hoverPoint && isDrawing) {
+          const eraserRadius = lineWidth * 6
+
+          ctx.strokeStyle = 'rgba(0, 0, 0, 0.3)'
+          ctx.lineWidth = 2
+          ctx.beginPath()
+          ctx.arc(hoverPoint.x, hoverPoint.y, eraserRadius, 0, 2 * Math.PI)
+          ctx.stroke()
+
+          ctx.strokeStyle = 'rgba(255, 255, 255, 0.6)'
+          ctx.lineWidth = 1
+          ctx.beginPath()
+          ctx.arc(hoverPoint.x, hoverPoint.y, eraserRadius - 1, 0, 2 * Math.PI)
+          ctx.stroke()
+        }
+      }
+
+      onRemove() {}
+    }
+
+    const overlay = new TileDrawingOverlay(canvas)
+    overlay.setMap(map)
+    overlayRef.current = overlay
+
+    const updateCanvasSize = () => {
+      google.maps.event.trigger(overlay, 'draw')
+    }
+
+    window.addEventListener('resize', updateCanvasSize)
+
+    // Listen for map events to redraw
+    const boundsListener = map.addListener('bounds_changed', () => {
+      google.maps.event.trigger(overlay, 'draw')
+    })
+
+    const zoomListener = map.addListener('zoom_changed', () => {
+      google.maps.event.trigger(overlay, 'draw')
+    })
+
+    return () => {
+      window.removeEventListener('resize', updateCanvasSize)
+      google.maps.event.removeListener(boundsListener)
+      google.maps.event.removeListener(zoomListener)
+      if (overlayRef.current) {
+        overlayRef.current.setMap(null)
+      }
+    }
+  }, [map, baseZoom, layers, tileCache])
+
+  // Redraw when current drawing changes
+  useEffect(() => {
+    if (overlayRef.current) {
+      google.maps.event.trigger(overlayRef.current, 'draw')
+    }
+  }, [currentPixelLine, startPoint, hoverPoint, isMouseDown])
+
+  // Redraw when layers change
+  useEffect(() => {
+    if (overlayRef.current) {
+      google.maps.event.trigger(overlayRef.current, 'draw')
+    }
+  }, [layers])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`drawing-canvas ${isDrawing ? 'drawing' : ''} ${selectedTool === 'eraser' ? 'eraser-cursor' : ''} ${selectedTool === 'pan' ? 'pan-mode' : ''}`}
+      onPointerDown={handlePointerStart}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: isDrawing ? 'auto' : 'none',
+        touchAction: 'none',
+        cursor: isDrawing ? (selectedTool === 'eraser' ? 'none' : 'crosshair') : 'default'
+      }}
+    />
+  )
+}
+
+export default DrawingCanvasV2

--- a/src/components/DrawingCanvasV2.tsx
+++ b/src/components/DrawingCanvasV2.tsx
@@ -58,6 +58,7 @@ function DrawingCanvasV2({
     selectedColor,
     lineWidth,
     activeLayerId,
+    baseZoom,
     tileCache,
     onDrawingComplete,
     onCurrentDrawingChange

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
-import type { Layer } from '../types'
+import type { LayerV2 } from '../types'
 
 interface LayerPanelProps {
-  layers: Layer[]
+  layers: LayerV2[]
   activeLayerId: string | null
   addLayer: (name?: string) => string
   removeLayer: (layerId: string) => void
-  updateLayer: (layerId: string, updates: Partial<Omit<Layer, 'id'>>) => void
+  updateLayer: (layerId: string, updates: Partial<Omit<LayerV2, 'id' | 'tiles'>>) => void
   setActiveLayer: (layerId: string) => void
   reorderLayers: (fromIndex: number, toIndex: number) => void
   toggleLayerVisibility: (layerId: string) => void
@@ -34,7 +34,7 @@ export const LayerPanel: React.FC<LayerPanelProps> = ({
 
   const sortedLayers = [...layers].sort((a, b) => b.order - a.order)
 
-  const handleStartEdit = (layer: Layer) => {
+  const handleStartEdit = (layer: LayerV2) => {
     setEditingLayerId(layer.id)
     setEditingName(layer.name)
   }

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app'
 import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
 import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth'
+import { getStorage, connectStorageEmulator } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -24,11 +25,13 @@ console.log('🔥 Firebase Config:', {
 const app = initializeApp(firebaseConfig)
 export const db = getFirestore(app)
 export const auth = getAuth(app)
+export const storage = getStorage(app)
 
 // 開発環境でFirestoreエミュレーターを使用（オプション）
 if (import.meta.env.DEV && import.meta.env.VITE_USE_FIRESTORE_EMULATOR === 'true') {
   console.log('🔥 Using Firestore emulator')
   connectFirestoreEmulator(db, 'localhost', 8080)
+  connectStorageEmulator(storage, 'localhost', 9199)
 }
 
 // デバッグ: Firestore初期化確認

--- a/src/hooks/useDrawingCanvasV2.ts
+++ b/src/hooks/useDrawingCanvasV2.ts
@@ -1,0 +1,517 @@
+import { useRef, useState, useCallback, useEffect } from 'react'
+import type { DrawingTool, TileCoord } from '../types'
+import { tileCoordToPixel, getAffectedTiles } from '../services/tileService'
+import type { TileCacheManager } from './useTileCache'
+
+interface DrawingEventCoords {
+  x: number
+  y: number
+  pressure: number
+  pointerId: number | null
+  type: 'mouse' | 'pen' | 'touch'
+}
+
+interface MapBounds {
+  north: number
+  south: number
+  east: number
+  west: number
+}
+
+export interface UseDrawingCanvasV2Return {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
+  overlayRef: React.MutableRefObject<google.maps.OverlayView | null>
+  isMouseDown: boolean
+  currentPixelLine: { x: number; y: number; pressure?: number }[]
+  startPoint: { x: number; y: number } | null
+  activePointerId: number | null
+  hoverPoint: { x: number; y: number } | null
+  handlePointerStart: (e: React.PointerEvent<HTMLCanvasElement>) => void
+  handlePointerMove: (e: React.PointerEvent<HTMLCanvasElement>) => void
+  handlePointerEnd: (e: React.PointerEvent<HTMLCanvasElement>) => void
+  handleTouchStart: (e: React.TouchEvent<HTMLCanvasElement>) => void
+  handleTouchMove: (e: React.TouchEvent<HTMLCanvasElement>) => void
+  handleTouchEnd: (e: React.TouchEvent<HTMLCanvasElement>) => void
+  handleMouseDown: (e: React.MouseEvent<HTMLCanvasElement>) => void
+  handleMouseMove: (e: React.MouseEvent<HTMLCanvasElement>) => void
+  handleMouseUp: (e: React.MouseEvent<HTMLCanvasElement>) => void
+  handleMouseLeave: () => void
+  cleanupOverlay: () => void
+}
+
+const TILE_SIZE_PX = 256
+
+export const useDrawingCanvasV2 = (
+  map: google.maps.Map | null,
+  isDrawing: boolean,
+  selectedTool: DrawingTool,
+  selectedColor: string,
+  lineWidth: number,
+  activeLayerId: string | null,
+  tileCache: TileCacheManager,
+  onDrawingComplete?: () => void,
+  onCurrentDrawingChange?: (hasCurrentDrawing: boolean) => void
+): UseDrawingCanvasV2Return => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const overlayRef = useRef<google.maps.OverlayView | null>(null)
+  const [isMouseDown, setIsMouseDown] = useState(false)
+  const [currentPixelLine, setCurrentPixelLine] = useState<{ x: number; y: number; pressure?: number }[]>([])
+  const [startPoint, setStartPoint] = useState<{ x: number; y: number } | null>(null)
+  const [activePointerId, setActivePointerId] = useState<number | null>(null)
+  const [hoverPoint, setHoverPoint] = useState<{ x: number; y: number } | null>(null)
+
+  // Report current drawing state to parent
+  useEffect(() => {
+    const hasDrawing = currentPixelLine.length > 0
+    onCurrentDrawingChange?.(hasDrawing)
+  }, [currentPixelLine, onCurrentDrawingChange])
+
+  const getEventCoordinates = useCallback((e: React.MouseEvent | React.PointerEvent | React.TouchEvent): DrawingEventCoords | null => {
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return null
+
+    let clientX: number, clientY: number, pressure = 0.5, pointerId: number | null = null, type: 'mouse' | 'pen' | 'touch' = 'mouse'
+
+    if ('pointerId' in e) {
+      clientX = e.clientX
+      clientY = e.clientY
+      if (e.pointerType === 'pen') {
+        pressure = e.pressure > 0 ? e.pressure : 0.5
+      } else {
+        pressure = e.pressure || 0.5
+      }
+      pointerId = e.pointerId
+      type = e.pointerType === 'pen' ? 'pen' : e.pointerType === 'touch' ? 'touch' : 'mouse'
+    } else if ('clientX' in e) {
+      clientX = e.clientX
+      clientY = e.clientY
+      pressure = 0.5
+      type = 'mouse'
+    } else if ('touches' in e && e.touches.length > 0) {
+      clientX = e.touches[0].clientX
+      clientY = e.touches[0].clientY
+      if ('force' in e.touches[0]) {
+        pressure = (e.touches[0] as any).force || 0.5
+      }
+      type = 'touch'
+    } else {
+      return null
+    }
+
+    return {
+      x: clientX - rect.left,
+      y: clientY - rect.top,
+      pressure,
+      pointerId,
+      type
+    }
+  }, [])
+
+  /**
+   * 現在のマップ状態を取得
+   */
+  const getMapState = useCallback(() => {
+    if (!map) return null
+
+    const bounds = map.getBounds()
+    const zoom = map.getZoom()
+    const canvas = canvasRef.current
+
+    if (!bounds || zoom === undefined || !canvas) return null
+
+    const ne = bounds.getNorthEast()
+    const sw = bounds.getSouthWest()
+
+    return {
+      mapBounds: {
+        north: ne.lat(),
+        south: sw.lat(),
+        east: ne.lng(),
+        west: sw.lng(),
+      },
+      zoom: Math.floor(zoom),
+      mapSize: {
+        width: canvas.width,
+        height: canvas.height,
+      }
+    }
+  }, [map])
+
+  /**
+   * ピクセル座標をタイル内のローカル座標に変換
+   */
+  const pixelToTileLocal = useCallback((
+    pixelX: number,
+    pixelY: number,
+    tileCoord: TileCoord,
+    mapBounds: MapBounds,
+    mapSize: { width: number; height: number }
+  ): { x: number; y: number } => {
+    // タイルの左上ピクセル座標を取得
+    const tilePixel = tileCoordToPixel(tileCoord, mapBounds, mapSize)
+
+    // タイル内のローカル座標を計算
+    // 現在のズームレベルでのタイルのピクセルサイズを計算
+    const totalTiles = Math.pow(2, tileCoord.zoom)
+    const worldWidth = mapSize.width / ((mapBounds.east - mapBounds.west) / 360)
+    const tilePixelSize = worldWidth / totalTiles
+
+    return {
+      x: ((pixelX - tilePixel.x) / tilePixelSize) * TILE_SIZE_PX,
+      y: ((pixelY - tilePixel.y) / tilePixelSize) * TILE_SIZE_PX,
+    }
+  }, [])
+
+  /**
+   * 線分をタイルCanvasに描画
+   */
+  const drawLineSegmentToTile = useCallback((
+    layerId: string,
+    tileCoord: TileCoord,
+    points: { x: number; y: number; pressure?: number }[],
+    mapBounds: MapBounds,
+    mapSize: { width: number; height: number }
+  ) => {
+    if (points.length < 2) return
+
+    const canvas = tileCache.getTileCanvas(layerId, tileCoord)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    ctx.strokeStyle = selectedColor
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+
+    if (selectedTool === 'eraser') {
+      ctx.globalCompositeOperation = 'destination-out'
+    } else {
+      ctx.globalCompositeOperation = 'source-over'
+    }
+
+    ctx.beginPath()
+
+    for (let i = 0; i < points.length - 1; i++) {
+      const p1 = points[i]
+      const p2 = points[i + 1]
+
+      // ピクセル座標をタイルローカル座標に変換
+      const local1 = pixelToTileLocal(p1.x, p1.y, tileCoord, mapBounds, mapSize)
+      const local2 = pixelToTileLocal(p2.x, p2.y, tileCoord, mapBounds, mapSize)
+
+      // 筆圧に基づく線幅
+      const pressure = p1.pressure ?? 0.5
+      const dynamicWidth = lineWidth * (0.3 + pressure * 0.7)
+      ctx.lineWidth = dynamicWidth
+
+      ctx.moveTo(local1.x, local1.y)
+      ctx.lineTo(local2.x, local2.y)
+      ctx.stroke()
+      ctx.beginPath()
+    }
+
+    // タイルを dirty としてマーク
+    tileCache.markTileDirty(layerId, tileCoord)
+  }, [selectedColor, selectedTool, lineWidth, tileCache, pixelToTileLocal])
+
+  /**
+   * 描画を完了（タイルに確定）
+   */
+  const finishDrawing = useCallback(() => {
+    if (!activeLayerId || currentPixelLine.length < 2) {
+      setCurrentPixelLine([])
+      setStartPoint(null)
+      setIsMouseDown(false)
+      setActivePointerId(null)
+      return
+    }
+
+    const mapState = getMapState()
+    if (!mapState) {
+      setCurrentPixelLine([])
+      setStartPoint(null)
+      setIsMouseDown(false)
+      setActivePointerId(null)
+      return
+    }
+
+    const { mapBounds, zoom, mapSize } = mapState
+
+    if (selectedTool === 'pen' || selectedTool === 'eraser') {
+      // 影響するタイルを特定
+      const affectedTiles = getAffectedTiles(
+        currentPixelLine,
+        lineWidth,
+        zoom,
+        mapBounds,
+        mapSize
+      )
+
+      // 各タイルに描画
+      for (const tileCoord of affectedTiles) {
+        drawLineSegmentToTile(
+          activeLayerId,
+          tileCoord,
+          currentPixelLine,
+          mapBounds,
+          mapSize
+        )
+      }
+    } else if (selectedTool === 'line' && startPoint && currentPixelLine.length > 0) {
+      const endPoint = currentPixelLine[currentPixelLine.length - 1]
+      const linePoints = [startPoint, endPoint]
+
+      const affectedTiles = getAffectedTiles(
+        linePoints,
+        lineWidth,
+        zoom,
+        mapBounds,
+        mapSize
+      )
+
+      for (const tileCoord of affectedTiles) {
+        drawLineSegmentToTile(
+          activeLayerId,
+          tileCoord,
+          linePoints,
+          mapBounds,
+          mapSize
+        )
+      }
+    } else if (selectedTool === 'rectangle' && startPoint && currentPixelLine.length > 0) {
+      const endPoint = currentPixelLine[currentPixelLine.length - 1]
+      const rectPoints = [
+        startPoint,
+        { x: endPoint.x, y: startPoint.y },
+        endPoint,
+        { x: startPoint.x, y: endPoint.y },
+        startPoint, // 閉じる
+      ]
+
+      const affectedTiles = getAffectedTiles(
+        rectPoints,
+        lineWidth,
+        zoom,
+        mapBounds,
+        mapSize
+      )
+
+      for (const tileCoord of affectedTiles) {
+        drawLineSegmentToTile(
+          activeLayerId,
+          tileCoord,
+          rectPoints,
+          mapBounds,
+          mapSize
+        )
+      }
+    } else if (selectedTool === 'circle' && startPoint && currentPixelLine.length > 0) {
+      const endPoint = currentPixelLine[currentPixelLine.length - 1]
+      const centerX = (startPoint.x + endPoint.x) / 2
+      const centerY = (startPoint.y + endPoint.y) / 2
+      const radiusX = Math.abs(endPoint.x - startPoint.x) / 2
+      const radiusY = Math.abs(endPoint.y - startPoint.y) / 2
+
+      // 円を近似する点を生成
+      const circlePoints: { x: number; y: number }[] = []
+      const segments = 64
+      for (let i = 0; i <= segments; i++) {
+        const angle = (i / segments) * Math.PI * 2
+        circlePoints.push({
+          x: centerX + radiusX * Math.cos(angle),
+          y: centerY + radiusY * Math.sin(angle),
+        })
+      }
+
+      const affectedTiles = getAffectedTiles(
+        circlePoints,
+        lineWidth,
+        zoom,
+        mapBounds,
+        mapSize
+      )
+
+      for (const tileCoord of affectedTiles) {
+        drawLineSegmentToTile(
+          activeLayerId,
+          tileCoord,
+          circlePoints,
+          mapBounds,
+          mapSize
+        )
+      }
+    }
+
+    // 状態をリセット
+    setCurrentPixelLine([])
+    setStartPoint(null)
+    setIsMouseDown(false)
+    setActivePointerId(null)
+
+    // 描画完了を通知
+    onDrawingComplete?.()
+  }, [
+    activeLayerId,
+    currentPixelLine,
+    startPoint,
+    selectedTool,
+    lineWidth,
+    getMapState,
+    drawLineSegmentToTile,
+    onDrawingComplete
+  ])
+
+  // Event handlers
+  const handlePointerStart = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || !activeLayerId) return
+
+    if (selectedTool === 'pan') return
+
+    if (activePointerId !== null && e.pointerType !== 'pen') return
+
+    e.preventDefault()
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    setActivePointerId(coords.pointerId)
+    setIsMouseDown(true)
+    setStartPoint({ x: coords.x, y: coords.y })
+    setCurrentPixelLine([coords])
+
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [isDrawing, activeLayerId, activePointerId, selectedTool, getEventCoordinates])
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!isDrawing) return
+
+    if (selectedTool === 'pan') return
+
+    e.preventDefault()
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    if (selectedTool === 'eraser' && !isMouseDown) {
+      setHoverPoint({ x: coords.x, y: coords.y })
+    }
+
+    if (!isMouseDown || activePointerId !== e.pointerId) return
+
+    if (selectedTool === 'pen' || selectedTool === 'eraser') {
+      setCurrentPixelLine(prev => [...prev, coords])
+    } else {
+      setCurrentPixelLine([coords])
+    }
+  }, [isDrawing, isMouseDown, activePointerId, selectedTool, getEventCoordinates])
+
+  const handlePointerEnd = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || activePointerId !== e.pointerId) return
+
+    e.preventDefault()
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    finishDrawing()
+  }, [isDrawing, activePointerId, finishDrawing])
+
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || activePointerId !== null || !activeLayerId) return
+
+    if (selectedTool === 'pan') return
+
+    e.preventDefault()
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    setIsMouseDown(true)
+    setStartPoint({ x: coords.x, y: coords.y })
+    setCurrentPixelLine([coords])
+  }, [isDrawing, activePointerId, activeLayerId, selectedTool, getEventCoordinates])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || !isMouseDown || activePointerId !== null) return
+
+    e.preventDefault()
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    if (selectedTool === 'pen' || selectedTool === 'eraser') {
+      setCurrentPixelLine(prev => [...prev, coords])
+    } else {
+      setCurrentPixelLine([coords])
+    }
+  }, [isDrawing, isMouseDown, activePointerId, selectedTool, getEventCoordinates])
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || activePointerId !== null) return
+
+    e.preventDefault()
+    finishDrawing()
+  }, [isDrawing, activePointerId, finishDrawing])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || activePointerId !== null || !activeLayerId) return
+
+    e.preventDefault()
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    setIsMouseDown(true)
+    setStartPoint({ x: coords.x, y: coords.y })
+    setCurrentPixelLine([coords])
+  }, [isDrawing, activePointerId, activeLayerId, getEventCoordinates])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing) return
+
+    const coords = getEventCoordinates(e)
+    if (!coords) return
+
+    if (selectedTool === 'eraser') {
+      setHoverPoint({ x: coords.x, y: coords.y })
+    }
+
+    if (!isMouseDown || activePointerId !== null) return
+
+    if (selectedTool === 'pen' || selectedTool === 'eraser') {
+      setCurrentPixelLine(prev => [...prev, coords])
+    } else {
+      setCurrentPixelLine([coords])
+    }
+  }, [isDrawing, isMouseDown, activePointerId, selectedTool, getEventCoordinates])
+
+  const handleMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || activePointerId !== null) return
+
+    e.preventDefault()
+    finishDrawing()
+  }, [isDrawing, activePointerId, finishDrawing])
+
+  const handleMouseLeave = useCallback(() => {
+    setHoverPoint(null)
+  }, [])
+
+  const cleanupOverlay = useCallback(() => {
+    if (overlayRef.current) {
+      overlayRef.current.setMap(null)
+      overlayRef.current = null
+    }
+  }, [])
+
+  return {
+    canvasRef,
+    overlayRef,
+    isMouseDown,
+    currentPixelLine,
+    startPoint,
+    activePointerId,
+    hoverPoint,
+    handlePointerStart,
+    handlePointerMove,
+    handlePointerEnd,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave,
+    cleanupOverlay
+  }
+}

--- a/src/hooks/useDrawingCanvasV2.ts
+++ b/src/hooks/useDrawingCanvasV2.ts
@@ -39,8 +39,6 @@ export interface UseDrawingCanvasV2Return {
   cleanupOverlay: () => void
 }
 
-const TILE_SIZE_PX = 256
-
 export const useDrawingCanvasV2 = (
   map: google.maps.Map | null,
   isDrawing: boolean,
@@ -158,8 +156,8 @@ export const useDrawingCanvasV2 = (
     const tilePixelSize = worldWidth / totalTiles
 
     return {
-      x: ((pixelX - tilePixel.x) / tilePixelSize) * TILE_SIZE_PX,
-      y: ((pixelY - tilePixel.y) / tilePixelSize) * TILE_SIZE_PX,
+      x: ((pixelX - tilePixel.x) / tilePixelSize) * 256,
+      y: ((pixelY - tilePixel.y) / tilePixelSize) * 256,
     }
   }, [])
 
@@ -364,6 +362,7 @@ export const useDrawingCanvasV2 = (
     startPoint,
     selectedTool,
     lineWidth,
+    baseZoom,
     getMapState,
     drawLineSegmentToTile,
     onDrawingComplete

--- a/src/hooks/useDrawingHistoryV2.ts
+++ b/src/hooks/useDrawingHistoryV2.ts
@@ -1,0 +1,199 @@
+import { useRef, useCallback } from 'react'
+import { parseTileKey } from '../services/tileService'
+import type { TileCacheManager } from './useTileCache'
+
+interface TileSnapshot {
+  tileKey: string
+  imageData: ImageData
+}
+
+interface LayerSnapshot {
+  layerId: string
+  tiles: TileSnapshot[]
+}
+
+interface HistoryEntry {
+  before: LayerSnapshot[]
+  after: LayerSnapshot[]
+}
+
+const MAX_HISTORY_SIZE = 20
+
+export function useDrawingHistoryV2(tileCache: TileCacheManager) {
+  const undoStackRef = useRef<HistoryEntry[]>([])
+  const redoStackRef = useRef<HistoryEntry[]>([])
+  const pendingSnapshotRef = useRef<LayerSnapshot[] | null>(null)
+
+  /**
+   * レイヤーの現在の状態をスナップショットとして保存
+   */
+  const captureLayerSnapshot = useCallback((layerId: string): LayerSnapshot => {
+    const tileKeys = tileCache.getLayerTileKeys(layerId)
+    const tiles: TileSnapshot[] = []
+
+    for (const tileKey of tileKeys) {
+      const coord = parseTileKey(tileKey)
+      const imageData = tileCache.getTileImageData(layerId, coord)
+      if (imageData) {
+        tiles.push({
+          tileKey,
+          imageData: new ImageData(
+            new Uint8ClampedArray(imageData.data),
+            imageData.width,
+            imageData.height
+          )
+        })
+      }
+    }
+
+    return { layerId, tiles }
+  }, [tileCache])
+
+  /**
+   * 描画開始前にスナップショットを保存
+   */
+  const saveSnapshot = useCallback((layerId: string) => {
+    const snapshot = captureLayerSnapshot(layerId)
+    pendingSnapshotRef.current = [snapshot]
+  }, [captureLayerSnapshot])
+
+  /**
+   * 描画完了後にスナップショットを確定してヒストリに追加
+   */
+  const commitSnapshot = useCallback((layerId: string) => {
+    if (!pendingSnapshotRef.current) return
+
+    const beforeSnapshot = pendingSnapshotRef.current
+    const afterSnapshot = [captureLayerSnapshot(layerId)]
+
+    // 変更があるかチェック
+    const hasChanges = beforeSnapshot.some((before, index) => {
+      const after = afterSnapshot[index]
+      if (before.tiles.length !== after.tiles.length) return true
+
+      return before.tiles.some((beforeTile, tileIndex) => {
+        const afterTile = after.tiles[tileIndex]
+        if (!afterTile || beforeTile.tileKey !== afterTile.tileKey) return true
+
+        // ImageData の比較
+        const beforeData = beforeTile.imageData.data
+        const afterData = afterTile.imageData.data
+        if (beforeData.length !== afterData.length) return true
+
+        for (let i = 0; i < beforeData.length; i++) {
+          if (beforeData[i] !== afterData[i]) return true
+        }
+        return false
+      })
+    })
+
+    if (hasChanges) {
+      undoStackRef.current.push({
+        before: beforeSnapshot,
+        after: afterSnapshot
+      })
+
+      // 最大サイズを超えたら古いエントリを削除
+      if (undoStackRef.current.length > MAX_HISTORY_SIZE) {
+        undoStackRef.current.shift()
+      }
+
+      // redo スタックをクリア
+      redoStackRef.current = []
+    }
+
+    pendingSnapshotRef.current = null
+  }, [captureLayerSnapshot])
+
+  /**
+   * スナップショットをキャンセル
+   */
+  const cancelSnapshot = useCallback(() => {
+    pendingSnapshotRef.current = null
+  }, [])
+
+  /**
+   * スナップショットを復元
+   */
+  const restoreSnapshot = useCallback((snapshots: LayerSnapshot[]) => {
+    for (const snapshot of snapshots) {
+      // 現在のタイルをクリア
+      tileCache.clearLayerTiles(snapshot.layerId)
+
+      // スナップショットからタイルを復元
+      for (const tile of snapshot.tiles) {
+        const coord = parseTileKey(tile.tileKey)
+        tileCache.setTileImageData(snapshot.layerId, coord, tile.imageData)
+        tileCache.markTileDirty(snapshot.layerId, coord)
+      }
+    }
+  }, [tileCache])
+
+  /**
+   * Undo
+   */
+  const undo = useCallback((): boolean => {
+    const entry = undoStackRef.current.pop()
+    if (!entry) return false
+
+    // redo スタックに追加
+    redoStackRef.current.push(entry)
+
+    // before 状態を復元
+    restoreSnapshot(entry.before)
+
+    return true
+  }, [restoreSnapshot])
+
+  /**
+   * Redo
+   */
+  const redo = useCallback((): boolean => {
+    const entry = redoStackRef.current.pop()
+    if (!entry) return false
+
+    // undo スタックに追加
+    undoStackRef.current.push(entry)
+
+    // after 状態を復元
+    restoreSnapshot(entry.after)
+
+    return true
+  }, [restoreSnapshot])
+
+  /**
+   * Undo 可能かどうか
+   */
+  const canUndo = useCallback((): boolean => {
+    return undoStackRef.current.length > 0
+  }, [])
+
+  /**
+   * Redo 可能かどうか
+   */
+  const canRedo = useCallback((): boolean => {
+    return redoStackRef.current.length > 0
+  }, [])
+
+  /**
+   * 履歴をクリア
+   */
+  const clear = useCallback(() => {
+    undoStackRef.current = []
+    redoStackRef.current = []
+    pendingSnapshotRef.current = null
+  }, [])
+
+  return {
+    saveSnapshot,
+    commitSnapshot,
+    cancelSnapshot,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    clear
+  }
+}
+
+export type DrawingHistoryV2 = ReturnType<typeof useDrawingHistoryV2>

--- a/src/hooks/useDrawingV2.ts
+++ b/src/hooks/useDrawingV2.ts
@@ -109,7 +109,9 @@ export const useDrawingV2 = (
 
       // Set base zoom from current map state
       const mapState = getCurrentMapState()
-      setBaseZoom(Math.floor(mapState.zoom))
+      const currentZoom = Math.floor(mapState.zoom)
+      console.log('🗺️ Setting baseZoom:', currentZoom, 'from map state:', mapState)
+      setBaseZoom(currentZoom)
     }
   }, [])
 
@@ -192,6 +194,22 @@ export const useDrawingV2 = (
       }
     }
   }, [isDrawing, scheduleAutoSave, tileCache])
+
+  // Update baseZoom when starting drawing mode if no tiles exist yet
+  useEffect(() => {
+    if (isDrawing) {
+      // Check if there are any existing tiles
+      const hasTiles = layers.some(layer => layer.tiles.length > 0)
+      if (!hasTiles) {
+        const mapState = getCurrentMapState()
+        const currentZoom = Math.floor(mapState.zoom)
+        if (currentZoom !== baseZoom) {
+          console.log('🗺️ Updating baseZoom from', baseZoom, 'to', currentZoom)
+          setBaseZoom(currentZoom)
+        }
+      }
+    }
+  }, [isDrawing, layers, baseZoom, getCurrentMapState])
 
   // Cleanup timeout on unmount
   useEffect(() => {

--- a/src/hooks/useDrawingV2.ts
+++ b/src/hooks/useDrawingV2.ts
@@ -144,17 +144,24 @@ export const useDrawingV2 = (
   }
 
   const handleAutoSave = useCallback(async () => {
+    console.log('🔄 handleAutoSave called:', { user: !!user, drawingId, userId: user?.uid })
+
     if (!user || !drawingId) {
+      console.log('⚠️ Save skipped: user or drawingId missing', { user: !!user, drawingId })
       return
     }
 
     const dirtyTiles = tileCache.getDirtyTiles()
+    console.log('🔄 Dirty tiles:', dirtyTiles.length)
+
     if (dirtyTiles.length === 0) {
+      console.log('⚠️ Save skipped: no dirty tiles')
       return
     }
 
     setIsSaving(true)
     try {
+      console.log('💾 Starting save...')
       const updatedLayers = await saveDrawingV2(
         drawingId,
         layers,
@@ -163,8 +170,9 @@ export const useDrawingV2 = (
         tileCache
       )
       setLayers(updatedLayers)
+      console.log('✅ Save completed successfully')
     } catch (error) {
-      console.error('Failed to auto-save drawing:', error)
+      console.error('❌ Failed to auto-save drawing:', error)
     } finally {
       setIsSaving(false)
     }

--- a/src/hooks/useDrawingV2.ts
+++ b/src/hooks/useDrawingV2.ts
@@ -1,0 +1,372 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { generateDrawingId, saveDrawingV2, loadDrawingV2 } from '../services/drawingService'
+import type { DrawingTool, LayerV2 } from '../types'
+import { useTileCache } from './useTileCache'
+import { useDrawingHistoryV2 } from './useDrawingHistoryV2'
+
+const DEFAULT_COLOR = '#ff4757'
+const DEFAULT_LINE_WIDTH = 3
+const AUTO_SAVE_DELAY = 1000
+const DEFAULT_ZOOM = 15
+
+function generateLayerId(): string {
+  return `layer_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+}
+
+export interface UseDrawingV2Return {
+  drawingId: string
+  layers: LayerV2[]
+  activeLayerId: string | null
+  baseZoom: number
+  selectedColor: string
+  selectedTool: DrawingTool
+  lineWidth: number
+  isDrawing: boolean
+  isSaving: boolean
+  hasCurrentDrawing: boolean
+  tileCache: ReturnType<typeof useTileCache>
+  setSelectedColor: (color: string) => void
+  setSelectedTool: (tool: DrawingTool) => void
+  setLineWidth: (width: number) => void
+  setIsDrawing: (isDrawing: boolean) => void
+  setHasCurrentDrawing: (has: boolean) => void
+  handleShare: () => void
+  loadDrawingData: (id: string) => Promise<void>
+  onDrawingComplete: () => void
+  clearAllTiles: () => void
+  undo: () => void
+  redo: () => void
+  canUndo: boolean
+  canRedo: boolean
+  addLayer: (name?: string) => string
+  removeLayer: (layerId: string) => void
+  updateLayer: (layerId: string, updates: Partial<Omit<LayerV2, 'id' | 'tiles'>>) => void
+  setActiveLayer: (layerId: string) => void
+  reorderLayers: (fromIndex: number, toIndex: number) => void
+  toggleLayerVisibility: (layerId: string) => void
+  toggleLayerLock: (layerId: string) => void
+  getVisibleLayers: () => LayerV2[]
+  isLayerLocked: (layerId: string) => boolean
+  isLayerVisible: (layerId: string) => boolean
+}
+
+export const useDrawingV2 = (
+  user: any,
+  getCurrentMapState: () => { center: { lat: number, lng: number }, zoom: number }
+): UseDrawingV2Return => {
+  const [drawingId, setDrawingId] = useState<string>('')
+  const [layers, setLayers] = useState<LayerV2[]>(() => {
+    const defaultLayer: LayerV2 = {
+      id: generateLayerId(),
+      name: 'Layer 1',
+      visible: true,
+      locked: false,
+      opacity: 1,
+      order: 0,
+      tiles: []
+    }
+    return [defaultLayer]
+  })
+  const [activeLayerId, setActiveLayerId] = useState<string | null>(null)
+  const [baseZoom, setBaseZoom] = useState<number>(DEFAULT_ZOOM)
+  const [selectedColor, setSelectedColor] = useState(DEFAULT_COLOR)
+  const [selectedTool, setSelectedTool] = useState<DrawingTool>('pan')
+  const [lineWidth, setLineWidth] = useState(DEFAULT_LINE_WIDTH)
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [hasCurrentDrawing, setHasCurrentDrawing] = useState(false)
+  const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const tileCache = useTileCache()
+  const history = useDrawingHistoryV2(tileCache)
+
+  // Set active layer to first layer if not set
+  useEffect(() => {
+    if (activeLayerId === null && layers.length > 0) {
+      setActiveLayerId(layers[0].id)
+    }
+  }, [layers, activeLayerId])
+
+  // Initialize layer in tile cache
+  useEffect(() => {
+    layers.forEach(layer => {
+      tileCache.initializeLayer(layer.id)
+    })
+  }, [layers, tileCache])
+
+  // Initialize drawing ID from URL or generate new one
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search)
+    const id = urlParams.get('id')
+
+    if (id) {
+      setDrawingId(id)
+      loadDrawingData(id)
+    } else {
+      const newId = generateDrawingId()
+      setDrawingId(newId)
+      window.history.replaceState({}, '', `?id=${newId}`)
+
+      // Set base zoom from current map state
+      const mapState = getCurrentMapState()
+      setBaseZoom(Math.floor(mapState.zoom))
+    }
+  }, [])
+
+  const loadDrawingData = async (id: string) => {
+    try {
+      const data = await loadDrawingV2(id)
+      if (data) {
+        setLayers(data.layers)
+        setBaseZoom(data.baseZoom)
+        if (data.activeLayerId) {
+          setActiveLayerId(data.activeLayerId)
+        }
+        history.clear()
+
+        // Load tiles into cache
+        for (const layer of data.layers) {
+          tileCache.initializeLayer(layer.id)
+          for (const tile of layer.tiles) {
+            try {
+              await tileCache.loadTileFromUrl(layer.id, tile.coord, tile.storageUrl)
+            } catch (error) {
+              console.error(`Failed to load tile: ${tile.storageUrl}`, error)
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load drawing:', error)
+    }
+  }
+
+  const handleAutoSave = useCallback(async () => {
+    if (!user || !drawingId) {
+      return
+    }
+
+    const dirtyTiles = tileCache.getDirtyTiles()
+    if (dirtyTiles.length === 0) {
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      const updatedLayers = await saveDrawingV2(
+        drawingId,
+        layers,
+        activeLayerId,
+        baseZoom,
+        tileCache
+      )
+      setLayers(updatedLayers)
+    } catch (error) {
+      console.error('Failed to auto-save drawing:', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [user, drawingId, layers, activeLayerId, baseZoom, tileCache])
+
+  const scheduleAutoSave = useCallback(() => {
+    if (autoSaveTimeoutRef.current) {
+      clearTimeout(autoSaveTimeoutRef.current)
+    }
+
+    autoSaveTimeoutRef.current = setTimeout(() => {
+      handleAutoSave()
+    }, AUTO_SAVE_DELAY)
+  }, [handleAutoSave])
+
+  const onDrawingComplete = useCallback(() => {
+    // Drawing completed, schedule auto-save
+    scheduleAutoSave()
+  }, [scheduleAutoSave])
+
+  // Auto-save when drawing mode ends
+  useEffect(() => {
+    if (!isDrawing) {
+      const dirtyTiles = tileCache.getDirtyTiles()
+      if (dirtyTiles.length > 0) {
+        scheduleAutoSave()
+      }
+    }
+  }, [isDrawing, scheduleAutoSave, tileCache])
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleShare = useCallback(() => {
+    const url = window.location.href
+    navigator.clipboard.writeText(url)
+    alert('Share link copied!')
+  }, [])
+
+  const clearAllTiles = useCallback(() => {
+    if (activeLayerId) {
+      // Save current state for undo
+      history.saveSnapshot(activeLayerId)
+
+      // Clear all tiles in active layer
+      tileCache.clearLayerTiles(activeLayerId)
+
+      // Schedule auto-save
+      scheduleAutoSave()
+    }
+  }, [activeLayerId, tileCache, history, scheduleAutoSave])
+
+  const undo = useCallback(() => {
+    if (history.canUndo()) {
+      history.undo()
+      scheduleAutoSave()
+    }
+  }, [history, scheduleAutoSave])
+
+  const redo = useCallback(() => {
+    if (history.canRedo()) {
+      history.redo()
+      scheduleAutoSave()
+    }
+  }, [history, scheduleAutoSave])
+
+  // Layer management functions
+  const addLayer = useCallback((name?: string): string => {
+    const newLayerId = generateLayerId()
+    const maxOrder = Math.max(...layers.map(l => l.order), -1)
+    const layerNumber = layers.length + 1
+
+    const newLayer: LayerV2 = {
+      id: newLayerId,
+      name: name || `Layer ${layerNumber}`,
+      visible: true,
+      locked: false,
+      opacity: 1,
+      order: maxOrder + 1,
+      tiles: []
+    }
+
+    setLayers(prev => [...prev, newLayer])
+    setActiveLayerId(newLayerId)
+    tileCache.initializeLayer(newLayerId)
+    return newLayerId
+  }, [layers, tileCache])
+
+  const removeLayer = useCallback((layerId: string) => {
+    if (layers.length <= 1) return
+
+    setLayers(prev => {
+      const newLayers = prev.filter(l => l.id !== layerId)
+      if (activeLayerId === layerId && newLayers.length > 0) {
+        setActiveLayerId(newLayers[0].id)
+      }
+      return newLayers
+    })
+
+    tileCache.removeLayer(layerId)
+  }, [layers.length, activeLayerId, tileCache])
+
+  const updateLayer = useCallback((layerId: string, updates: Partial<Omit<LayerV2, 'id' | 'tiles'>>) => {
+    setLayers(prev =>
+      prev.map(layer =>
+        layer.id === layerId ? { ...layer, ...updates } : layer
+      )
+    )
+  }, [])
+
+  const setActiveLayer = useCallback((layerId: string) => {
+    const layer = layers.find(l => l.id === layerId)
+    if (layer && !layer.locked) {
+      setActiveLayerId(layerId)
+    }
+  }, [layers])
+
+  const reorderLayers = useCallback((fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return
+
+    setLayers(prev => {
+      const newLayers = [...prev]
+      const [movedLayer] = newLayers.splice(fromIndex, 1)
+      newLayers.splice(toIndex, 0, movedLayer)
+
+      return newLayers.map((layer, index) => ({
+        ...layer,
+        order: index
+      }))
+    })
+  }, [])
+
+  const toggleLayerVisibility = useCallback((layerId: string) => {
+    const layer = layers.find(l => l.id === layerId)
+    if (layer) {
+      updateLayer(layerId, { visible: !layer.visible })
+    }
+  }, [layers, updateLayer])
+
+  const toggleLayerLock = useCallback((layerId: string) => {
+    const layer = layers.find(l => l.id === layerId)
+    if (layer) {
+      updateLayer(layerId, { locked: !layer.locked })
+      if (!layer.locked && activeLayerId === layerId) {
+        const firstUnlockedLayer = layers.find(l => l.id !== layerId && !l.locked)
+        if (firstUnlockedLayer) {
+          setActiveLayerId(firstUnlockedLayer.id)
+        }
+      }
+    }
+  }, [layers, activeLayerId, updateLayer])
+
+  const getVisibleLayers = useCallback(() => {
+    return layers.filter(layer => layer.visible).sort((a, b) => a.order - b.order)
+  }, [layers])
+
+  const isLayerLocked = useCallback((layerId: string) => {
+    return layers.find(l => l.id === layerId)?.locked || false
+  }, [layers])
+
+  const isLayerVisible = useCallback((layerId: string) => {
+    return layers.find(l => l.id === layerId)?.visible || false
+  }, [layers])
+
+  return {
+    drawingId,
+    layers,
+    activeLayerId,
+    baseZoom,
+    selectedColor,
+    selectedTool,
+    lineWidth,
+    isDrawing,
+    isSaving,
+    hasCurrentDrawing,
+    tileCache,
+    setSelectedColor,
+    setSelectedTool,
+    setLineWidth,
+    setIsDrawing,
+    setHasCurrentDrawing,
+    handleShare,
+    loadDrawingData,
+    onDrawingComplete,
+    clearAllTiles,
+    undo,
+    redo,
+    canUndo: history.canUndo(),
+    canRedo: history.canRedo(),
+    addLayer,
+    removeLayer,
+    updateLayer,
+    setActiveLayer,
+    reorderLayers,
+    toggleLayerVisibility,
+    toggleLayerLock,
+    getVisibleLayers,
+    isLayerLocked,
+    isLayerVisible
+  }
+}

--- a/src/hooks/useTileCache.ts
+++ b/src/hooks/useTileCache.ts
@@ -1,0 +1,240 @@
+import { useRef, useCallback } from 'react'
+import { TileCoord, TileCacheEntry, TILE_SIZE } from '../types'
+import { getTileKey, parseTileKey, createEmptyTileCanvas, downloadTile } from '../services/tileService'
+
+interface TileCacheMap {
+  [layerId: string]: {
+    [tileKey: string]: TileCacheEntry
+  }
+}
+
+export function useTileCache() {
+  const cacheRef = useRef<TileCacheMap>({})
+
+  /**
+   * レイヤーのキャッシュを初期化
+   */
+  const initializeLayer = useCallback((layerId: string) => {
+    if (!cacheRef.current[layerId]) {
+      cacheRef.current[layerId] = {}
+    }
+  }, [])
+
+  /**
+   * レイヤーのキャッシュを削除
+   */
+  const removeLayer = useCallback((layerId: string) => {
+    delete cacheRef.current[layerId]
+  }, [])
+
+  /**
+   * タイルCanvasを取得（存在しなければ作成）
+   */
+  const getTileCanvas = useCallback((layerId: string, coord: TileCoord): HTMLCanvasElement => {
+    initializeLayer(layerId)
+    const tileKey = getTileKey(coord)
+
+    if (!cacheRef.current[layerId][tileKey]) {
+      cacheRef.current[layerId][tileKey] = {
+        canvas: createEmptyTileCanvas(),
+        dirty: false,
+      }
+    }
+
+    return cacheRef.current[layerId][tileKey].canvas
+  }, [initializeLayer])
+
+  /**
+   * タイルを dirty としてマーク
+   */
+  const markTileDirty = useCallback((layerId: string, coord: TileCoord) => {
+    initializeLayer(layerId)
+    const tileKey = getTileKey(coord)
+
+    if (cacheRef.current[layerId][tileKey]) {
+      cacheRef.current[layerId][tileKey].dirty = true
+    }
+  }, [initializeLayer])
+
+  /**
+   * 全ての dirty タイルを取得
+   */
+  const getDirtyTiles = useCallback((): { layerId: string; coord: TileCoord; canvas: HTMLCanvasElement }[] => {
+    const dirtyTiles: { layerId: string; coord: TileCoord; canvas: HTMLCanvasElement }[] = []
+
+    for (const layerId of Object.keys(cacheRef.current)) {
+      for (const tileKey of Object.keys(cacheRef.current[layerId])) {
+        const entry = cacheRef.current[layerId][tileKey]
+        if (entry.dirty) {
+          dirtyTiles.push({
+            layerId,
+            coord: parseTileKey(tileKey),
+            canvas: entry.canvas,
+          })
+        }
+      }
+    }
+
+    return dirtyTiles
+  }, [])
+
+  /**
+   * dirty フラグをクリア
+   */
+  const clearDirtyFlags = useCallback(() => {
+    for (const layerId of Object.keys(cacheRef.current)) {
+      for (const tileKey of Object.keys(cacheRef.current[layerId])) {
+        cacheRef.current[layerId][tileKey].dirty = false
+      }
+    }
+  }, [])
+
+  /**
+   * 特定のタイルの dirty フラグをクリア
+   */
+  const clearTileDirtyFlag = useCallback((layerId: string, coord: TileCoord) => {
+    const tileKey = getTileKey(coord)
+    if (cacheRef.current[layerId]?.[tileKey]) {
+      cacheRef.current[layerId][tileKey].dirty = false
+    }
+  }, [])
+
+  /**
+   * URLからタイルを読み込んでキャッシュに追加
+   */
+  const loadTileFromUrl = useCallback(async (
+    layerId: string,
+    coord: TileCoord,
+    url: string
+  ): Promise<HTMLCanvasElement> => {
+    initializeLayer(layerId)
+    const tileKey = getTileKey(coord)
+
+    // 画像をダウンロード
+    const img = await downloadTile(url)
+
+    // Canvasに描画
+    const canvas = createEmptyTileCanvas()
+    const ctx = canvas.getContext('2d')
+    if (ctx) {
+      ctx.drawImage(img, 0, 0, TILE_SIZE, TILE_SIZE)
+    }
+
+    // キャッシュに追加
+    cacheRef.current[layerId][tileKey] = {
+      canvas,
+      dirty: false,
+    }
+
+    return canvas
+  }, [initializeLayer])
+
+  /**
+   * レイヤーの全タイルキーを取得
+   */
+  const getLayerTileKeys = useCallback((layerId: string): string[] => {
+    if (!cacheRef.current[layerId]) {
+      return []
+    }
+    return Object.keys(cacheRef.current[layerId])
+  }, [])
+
+  /**
+   * タイルのImageDataを取得
+   */
+  const getTileImageData = useCallback((layerId: string, coord: TileCoord): ImageData | null => {
+    const tileKey = getTileKey(coord)
+    const entry = cacheRef.current[layerId]?.[tileKey]
+    if (!entry) return null
+
+    const ctx = entry.canvas.getContext('2d')
+    if (!ctx) return null
+
+    return ctx.getImageData(0, 0, TILE_SIZE, TILE_SIZE)
+  }, [])
+
+  /**
+   * タイルにImageDataを設定
+   */
+  const setTileImageData = useCallback((layerId: string, coord: TileCoord, imageData: ImageData) => {
+    initializeLayer(layerId)
+    const tileKey = getTileKey(coord)
+
+    if (!cacheRef.current[layerId][tileKey]) {
+      cacheRef.current[layerId][tileKey] = {
+        canvas: createEmptyTileCanvas(),
+        dirty: false,
+      }
+    }
+
+    const ctx = cacheRef.current[layerId][tileKey].canvas.getContext('2d')
+    if (ctx) {
+      ctx.putImageData(imageData, 0, 0)
+    }
+  }, [initializeLayer])
+
+  /**
+   * タイルをクリア
+   */
+  const clearTile = useCallback((layerId: string, coord: TileCoord) => {
+    const tileKey = getTileKey(coord)
+    const entry = cacheRef.current[layerId]?.[tileKey]
+    if (!entry) return
+
+    const ctx = entry.canvas.getContext('2d')
+    if (ctx) {
+      ctx.clearRect(0, 0, TILE_SIZE, TILE_SIZE)
+    }
+  }, [])
+
+  /**
+   * レイヤーの全タイルをクリア
+   */
+  const clearLayerTiles = useCallback((layerId: string) => {
+    if (!cacheRef.current[layerId]) return
+
+    for (const tileKey of Object.keys(cacheRef.current[layerId])) {
+      const entry = cacheRef.current[layerId][tileKey]
+      const ctx = entry.canvas.getContext('2d')
+      if (ctx) {
+        ctx.clearRect(0, 0, TILE_SIZE, TILE_SIZE)
+      }
+      entry.dirty = true
+    }
+  }, [])
+
+  /**
+   * 全キャッシュをクリア
+   */
+  const clearAllCache = useCallback(() => {
+    cacheRef.current = {}
+  }, [])
+
+  /**
+   * タイルが存在するかチェック
+   */
+  const hasTile = useCallback((layerId: string, coord: TileCoord): boolean => {
+    const tileKey = getTileKey(coord)
+    return !!cacheRef.current[layerId]?.[tileKey]
+  }, [])
+
+  return {
+    getTileCanvas,
+    markTileDirty,
+    getDirtyTiles,
+    clearDirtyFlags,
+    clearTileDirtyFlag,
+    loadTileFromUrl,
+    getLayerTileKeys,
+    getTileImageData,
+    setTileImageData,
+    clearTile,
+    clearLayerTiles,
+    clearAllCache,
+    initializeLayer,
+    removeLayer,
+    hasTile,
+  }
+}
+
+export type TileCacheManager = ReturnType<typeof useTileCache>

--- a/src/services/drawingService.ts
+++ b/src/services/drawingService.ts
@@ -7,9 +7,12 @@ import {
   Timestamp
 } from 'firebase/firestore'
 import { db } from '../firebase'
-import type { DrawingData, Shape, Layer } from '../types'
+import type { DrawingData, Shape, Layer, DrawingDataV2, LayerV2, TileCoord } from '../types'
+import { uploadTile, getTileKey } from './tileService'
+import type { TileCacheManager } from '../hooks/useTileCache'
 
 const COLLECTION_NAME = 'drawings'
+const COLLECTION_NAME_V2 = 'drawings_v2'
 
 export const generateDrawingId = (): string => {
   return Math.random().toString(36).substring(2, 15) +
@@ -80,5 +83,159 @@ export const loadDrawing = async (drawingId: string): Promise<DrawingData | null
   } catch (error) {
     console.error('❌ Load error:', error)
     throw error
+  }
+}
+
+// ============================================
+// V2 タイルベース描画システム用の関数
+// ============================================
+
+/**
+ * V2形式の描画データを保存
+ * dirty タイルをFirebase Storageにアップロードし、メタデータをFirestoreに保存
+ */
+export const saveDrawingV2 = async (
+  drawingId: string,
+  layers: LayerV2[],
+  activeLayerId: string | null,
+  baseZoom: number,
+  tileCache: TileCacheManager
+): Promise<LayerV2[]> => {
+  try {
+    // dirty タイルをアップロード
+    const dirtyTiles = tileCache.getDirtyTiles()
+    const uploadPromises: Promise<{ layerId: string; coord: TileCoord; url: string }>[] = []
+
+    for (const { layerId, coord, canvas } of dirtyTiles) {
+      uploadPromises.push(
+        uploadTile(drawingId, layerId, coord, canvas).then(url => ({
+          layerId,
+          coord,
+          url
+        }))
+      )
+    }
+
+    const uploadedTiles = await Promise.all(uploadPromises)
+
+    // レイヤーデータを更新（アップロードしたタイルのURLを追加）
+    const updatedLayers = layers.map(layer => {
+      const layerTiles = uploadedTiles.filter(t => t.layerId === layer.id)
+
+      // 既存のタイルと新しいタイルをマージ
+      const existingTiles = new Map(
+        layer.tiles.map(t => [getTileKey(t.coord), t])
+      )
+
+      for (const { coord, url } of layerTiles) {
+        existingTiles.set(getTileKey(coord), {
+          coord,
+          storageUrl: url,
+          updatedAt: new Date()
+        })
+      }
+
+      return {
+        ...layer,
+        tiles: Array.from(existingTiles.values())
+      }
+    })
+
+    // Firestoreにメタデータを保存
+    const drawingRef = doc(db, COLLECTION_NAME_V2, drawingId)
+    const drawingData = {
+      version: 2,
+      layers: updatedLayers.map(layer => ({
+        id: layer.id,
+        name: layer.name,
+        visible: layer.visible,
+        locked: layer.locked,
+        opacity: layer.opacity,
+        order: layer.order,
+        tiles: layer.tiles.map(tile => ({
+          coord: tile.coord,
+          storageUrl: tile.storageUrl,
+          updatedAt: tile.updatedAt
+        }))
+      })),
+      activeLayerId,
+      baseZoom,
+      updatedAt: serverTimestamp()
+    }
+
+    const existingDoc = await getDoc(drawingRef)
+
+    if (existingDoc.exists()) {
+      await updateDoc(drawingRef, drawingData)
+    } else {
+      await setDoc(drawingRef, {
+        ...drawingData,
+        createdAt: serverTimestamp()
+      })
+    }
+
+    // dirty フラグをクリア
+    tileCache.clearDirtyFlags()
+
+    return updatedLayers
+  } catch (error) {
+    console.error('❌ V2 Save error:', error)
+    throw error
+  }
+}
+
+/**
+ * V2形式の描画データを読み込み
+ */
+export const loadDrawingV2 = async (drawingId: string): Promise<DrawingDataV2 | null> => {
+  try {
+    const drawingRef = doc(db, COLLECTION_NAME_V2, drawingId)
+    const drawingSnap = await getDoc(drawingRef)
+
+    if (drawingSnap.exists()) {
+      const data = drawingSnap.data()
+      return {
+        id: drawingId,
+        version: 2,
+        layers: (data.layers || []).map((layer: any) => ({
+          id: layer.id,
+          name: layer.name,
+          visible: layer.visible,
+          locked: layer.locked,
+          opacity: layer.opacity,
+          order: layer.order,
+          tiles: (layer.tiles || []).map((tile: any) => ({
+            coord: tile.coord,
+            storageUrl: tile.storageUrl,
+            updatedAt: tile.updatedAt instanceof Timestamp
+              ? tile.updatedAt.toDate()
+              : new Date(tile.updatedAt)
+          }))
+        })),
+        activeLayerId: data.activeLayerId,
+        baseZoom: data.baseZoom,
+        createdAt: (data.createdAt as Timestamp).toDate(),
+        updatedAt: (data.updatedAt as Timestamp).toDate(),
+        userId: data.userId
+      }
+    }
+
+    return null
+  } catch (error) {
+    console.error('❌ V2 Load error:', error)
+    throw error
+  }
+}
+
+/**
+ * V2形式かどうかを判定
+ */
+export const isV2Drawing = async (drawingId: string): Promise<boolean> => {
+  try {
+    const drawingRef = doc(db, COLLECTION_NAME_V2, drawingId)
+    const drawingSnap = await getDoc(drawingRef)
+    return drawingSnap.exists()
+  } catch (error) {
+    return false
   }
 }

--- a/src/services/drawingService.ts
+++ b/src/services/drawingService.ts
@@ -155,7 +155,7 @@ export const saveDrawingV2 = async (
         tiles: layer.tiles.map(tile => ({
           coord: tile.coord,
           storageUrl: tile.storageUrl,
-          updatedAt: tile.updatedAt
+          updatedAt: Timestamp.fromDate(tile.updatedAt instanceof Date ? tile.updatedAt : new Date(tile.updatedAt))
         }))
       })),
       activeLayerId,
@@ -163,15 +163,30 @@ export const saveDrawingV2 = async (
       updatedAt: serverTimestamp()
     }
 
+    console.log('📝 Saving to Firestore:', {
+      drawingId,
+      layerCount: updatedLayers.length,
+      tileCount: updatedLayers.reduce((sum, l) => sum + l.tiles.length, 0),
+      baseZoom,
+      drawingData
+    })
+
     const existingDoc = await getDoc(drawingRef)
 
-    if (existingDoc.exists()) {
-      await updateDoc(drawingRef, drawingData)
-    } else {
-      await setDoc(drawingRef, {
-        ...drawingData,
-        createdAt: serverTimestamp()
-      })
+    try {
+      if (existingDoc.exists()) {
+        await updateDoc(drawingRef, drawingData)
+        console.log('✅ Firestore updated')
+      } else {
+        await setDoc(drawingRef, {
+          ...drawingData,
+          createdAt: serverTimestamp()
+        })
+        console.log('✅ Firestore created')
+      }
+    } catch (firestoreError) {
+      console.error('❌ Firestore write failed:', firestoreError)
+      throw firestoreError
     }
 
     // dirty フラグをクリア

--- a/src/services/tileService.ts
+++ b/src/services/tileService.ts
@@ -1,0 +1,267 @@
+import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage'
+import { storage } from '../firebase'
+import { TileCoord, TILE_SIZE } from '../types'
+
+/**
+ * ピクセル座標からタイル座標を計算
+ * Google Maps のタイル座標系に合わせた計算
+ */
+export function pixelToTileCoord(
+  pixelX: number,
+  pixelY: number,
+  zoom: number,
+  mapBounds: { north: number; south: number; east: number; west: number },
+  mapSize: { width: number; height: number }
+): TileCoord {
+  // マップの総タイル数（2^zoom）
+  const totalTiles = Math.pow(2, zoom)
+
+  // ピクセル座標を経度緯度に変換
+  const lng = mapBounds.west + (pixelX / mapSize.width) * (mapBounds.east - mapBounds.west)
+  const lat = mapBounds.north - (pixelY / mapSize.height) * (mapBounds.north - mapBounds.south)
+
+  // 経度からタイルX座標を計算
+  const x = Math.floor(((lng + 180) / 360) * totalTiles)
+
+  // 緯度からタイルY座標を計算（メルカトル投影）
+  const latRad = (lat * Math.PI) / 180
+  const y = Math.floor(
+    ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * totalTiles
+  )
+
+  return { zoom, x, y }
+}
+
+/**
+ * タイル座標からピクセル座標（タイルの左上）を計算
+ */
+export function tileCoordToPixel(
+  coord: TileCoord,
+  mapBounds: { north: number; south: number; east: number; west: number },
+  mapSize: { width: number; height: number }
+): { x: number; y: number } {
+  const totalTiles = Math.pow(2, coord.zoom)
+
+  // タイルX座標から経度を計算
+  const lng = (coord.x / totalTiles) * 360 - 180
+
+  // タイルY座標から緯度を計算（メルカトル投影）
+  const n = Math.PI - (2 * Math.PI * coord.y) / totalTiles
+  const lat = (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)))
+
+  // 経度緯度からピクセル座標に変換
+  const x = ((lng - mapBounds.west) / (mapBounds.east - mapBounds.west)) * mapSize.width
+  const y = ((mapBounds.north - lat) / (mapBounds.north - mapBounds.south)) * mapSize.height
+
+  return { x, y }
+}
+
+/**
+ * タイル座標からキー文字列を生成
+ */
+export function getTileKey(coord: TileCoord): string {
+  return `${coord.zoom}_${coord.x}_${coord.y}`
+}
+
+/**
+ * キー文字列からタイル座標をパース
+ */
+export function parseTileKey(key: string): TileCoord {
+  const [zoom, x, y] = key.split('_').map(Number)
+  return { zoom, x, y }
+}
+
+/**
+ * 可視範囲のタイル座標一覧を取得
+ */
+export function getVisibleTiles(
+  mapBounds: { north: number; south: number; east: number; west: number },
+  zoom: number
+): TileCoord[] {
+  const totalTiles = Math.pow(2, zoom)
+  const tiles: TileCoord[] = []
+
+  // 西端と東端のタイルX座標
+  const minX = Math.floor(((mapBounds.west + 180) / 360) * totalTiles)
+  const maxX = Math.floor(((mapBounds.east + 180) / 360) * totalTiles)
+
+  // 北端と南端のタイルY座標
+  const northRad = (mapBounds.north * Math.PI) / 180
+  const southRad = (mapBounds.south * Math.PI) / 180
+  const minY = Math.floor(
+    ((1 - Math.log(Math.tan(northRad) + 1 / Math.cos(northRad)) / Math.PI) / 2) * totalTiles
+  )
+  const maxY = Math.floor(
+    ((1 - Math.log(Math.tan(southRad) + 1 / Math.cos(southRad)) / Math.PI) / 2) * totalTiles
+  )
+
+  // 可視範囲のタイルを列挙
+  for (let x = minX; x <= maxX; x++) {
+    for (let y = minY; y <= maxY; y++) {
+      // タイル座標の範囲チェック
+      if (x >= 0 && x < totalTiles && y >= 0 && y < totalTiles) {
+        tiles.push({ zoom, x, y })
+      }
+    }
+  }
+
+  return tiles
+}
+
+/**
+ * CanvasをWebPに変換してFirebase Storageにアップロード
+ */
+export async function uploadTile(
+  drawingId: string,
+  layerId: string,
+  coord: TileCoord,
+  canvas: HTMLCanvasElement
+): Promise<string> {
+  const tileKey = getTileKey(coord)
+  const path = `drawings/${drawingId}/layers/${layerId}/tiles/${tileKey}.webp`
+  const storageRef = ref(storage, path)
+
+  // CanvasをWebP Blobに変換
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+        } else {
+          reject(new Error('Failed to convert canvas to blob'))
+        }
+      },
+      'image/webp',
+      0.9 // 品質
+    )
+  })
+
+  // アップロード
+  await uploadBytes(storageRef, blob, {
+    contentType: 'image/webp',
+  })
+
+  // ダウンロードURLを取得
+  return getDownloadURL(storageRef)
+}
+
+/**
+ * Firebase Storageからタイル画像をダウンロード
+ */
+export async function downloadTile(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.onload = () => resolve(img)
+    img.onerror = (e) => reject(new Error(`Failed to load tile: ${e}`))
+    img.src = url
+  })
+}
+
+/**
+ * Firebase Storageからタイルを削除
+ */
+export async function deleteTile(
+  drawingId: string,
+  layerId: string,
+  coord: TileCoord
+): Promise<void> {
+  const tileKey = getTileKey(coord)
+  const path = `drawings/${drawingId}/layers/${layerId}/tiles/${tileKey}.webp`
+  const storageRef = ref(storage, path)
+
+  try {
+    await deleteObject(storageRef)
+  } catch (error: any) {
+    // ファイルが存在しない場合は無視
+    if (error.code !== 'storage/object-not-found') {
+      throw error
+    }
+  }
+}
+
+/**
+ * レイヤーの全タイルを削除
+ */
+export async function deleteLayerTiles(
+  drawingId: string,
+  layerId: string,
+  tiles: TileCoord[]
+): Promise<void> {
+  await Promise.all(
+    tiles.map((coord) => deleteTile(drawingId, layerId, coord))
+  )
+}
+
+/**
+ * 描画の全タイルを削除
+ */
+export async function deleteDrawingTiles(
+  drawingId: string,
+  layers: { id: string; tiles: TileCoord[] }[]
+): Promise<void> {
+  await Promise.all(
+    layers.map((layer) => deleteLayerTiles(drawingId, layer.id, layer.tiles))
+  )
+}
+
+/**
+ * 空のタイルCanvasを作成
+ */
+export function createEmptyTileCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = TILE_SIZE
+  canvas.height = TILE_SIZE
+  return canvas
+}
+
+/**
+ * タイルCanvasが空かどうかを判定
+ */
+export function isTileEmpty(canvas: HTMLCanvasElement): boolean {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return true
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const data = imageData.data
+
+  // アルファチャンネルをチェック（全て0なら空）
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i] > 0) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * 描画がまたがるタイル一覧を取得
+ */
+export function getAffectedTiles(
+  points: { x: number; y: number }[],
+  lineWidth: number,
+  zoom: number,
+  mapBounds: { north: number; south: number; east: number; west: number },
+  mapSize: { width: number; height: number }
+): TileCoord[] {
+  const tileSet = new Set<string>()
+  const halfWidth = lineWidth / 2
+
+  for (const point of points) {
+    // 線幅を考慮した範囲の4隅をチェック
+    const corners = [
+      { x: point.x - halfWidth, y: point.y - halfWidth },
+      { x: point.x + halfWidth, y: point.y - halfWidth },
+      { x: point.x - halfWidth, y: point.y + halfWidth },
+      { x: point.x + halfWidth, y: point.y + halfWidth },
+    ]
+
+    for (const corner of corners) {
+      const coord = pixelToTileCoord(corner.x, corner.y, zoom, mapBounds, mapSize)
+      tileSet.add(getTileKey(coord))
+    }
+  }
+
+  return Array.from(tileSet).map(parseTileKey)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,82 @@ export interface HistoryState {
   redoStack: DrawingCommand[]
   maxHistorySize: number
 }
+
+// ============================================
+// V2 タイルベース描画システム用の型定義
+// ============================================
+
+/** タイル座標 */
+export interface TileCoord {
+  zoom: number  // 描画時のズームレベル
+  x: number     // タイルX座標
+  y: number     // タイルY座標
+}
+
+/** タイル情報 */
+export interface Tile {
+  coord: TileCoord
+  storageUrl: string       // Firebase Storage URL
+  updatedAt: Date
+}
+
+/** レイヤー（V2タイル方式） */
+export interface LayerV2 {
+  id: string
+  name: string
+  visible: boolean
+  locked: boolean
+  opacity: number
+  order: number
+  tiles: Tile[]            // このレイヤーのタイル一覧
+}
+
+/** 描画データV2（新コレクション: drawings_v2） */
+export interface DrawingDataV2 {
+  id?: string
+  version: 2
+  layers: LayerV2[]
+  activeLayerId?: string
+  baseZoom: number         // 描画の基準ズームレベル
+  createdAt: Date
+  updatedAt: Date
+  userId?: string
+}
+
+/** タイルキャッシュエントリ */
+export interface TileCacheEntry {
+  canvas: HTMLCanvasElement
+  dirty: boolean           // 未保存の変更あり
+}
+
+/** タイルキャッシュ構造 */
+export interface TileCache {
+  [layerId: string]: {
+    [tileKey: string]: TileCacheEntry
+  }
+}
+
+/** V2用のUndo/Redoコマンド */
+export interface DrawingCommandV2 {
+  type: 'DRAW' | 'ERASE' | 'CLEAR_LAYER'
+  execute: () => void
+  undo: () => void
+  data: {
+    layerId: string
+    tileSnapshots: {
+      tileKey: string
+      beforeImageData: ImageData
+      afterImageData: ImageData
+    }[]
+  }
+}
+
+/** V2用の履歴状態 */
+export interface HistoryStateV2 {
+  undoStack: DrawingCommandV2[]
+  redoStack: DrawingCommandV2[]
+  maxHistorySize: number
+}
+
+/** タイル定数 */
+export const TILE_SIZE = 256

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    // drawings/{drawingId}/layers/{layerId}/tiles/{tileKey}.webp
+    match /drawings/{drawingId}/{allPaths=**} {
+      allow read: if true;                    // 誰でもタイルを見ることができる
+      allow write: if request.auth != null;   // 認証済みユーザーのみアップロード可能
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- ベクターベース（Firestoreにlat/lng座標配列）からタイルベースのビットマップ描画（Firebase StorageにWebP画像）に移行
- 256×256ピクセルのタイル方式を採用し、zoom/x/yでキー管理
- レイヤー機能とUndo/Redo機能を維持
- 新しいFirestoreコレクション `drawings_v2` でメタデータを管理（既存データは保持）

## Changes

### New Files
| File | Description |
|------|-------------|
| `storage.rules` | Firebase Storageセキュリティルール |
| `src/services/tileService.ts` | タイル座標変換、Firebase Storageへのアップロード/ダウンロード |
| `src/hooks/useTileCache.ts` | メモリ内タイルCanvas管理（dirtyフラグ付き） |
| `src/hooks/useDrawingV2.ts` | V2描画状態管理と自動保存 |
| `src/hooks/useDrawingCanvasV2.ts` | V2キャンバスイベント処理とタイル描画 |
| `src/hooks/useDrawingHistoryV2.ts` | ImageDataスナップショットによるUndo/Redo |
| `src/components/DrawingCanvasV2.tsx` | V2キャンバスレンダリングコンポーネント |

### Modified Files
- `src/types.ts`: V2型定義追加 (`TileCoord`, `Tile`, `LayerV2`, `DrawingDataV2`)
- `src/firebase.ts`: Firebase Storage初期化追加
- `src/services/drawingService.ts`: V2保存/読み込み関数追加
- `src/App.tsx`: V2コンポーネント統合
- `firebase.json`, `firestore.rules`: Storage設定とルール追加

## Architecture

```
描画イベント → タイル座標特定 → タイルCanvasに描画 → WebP化してFirebase Storageにアップロード
                                                    ↓
                                    Firestoreにメタデータ保存（タイル一覧、レイヤー情報）
```

## Test plan

- [ ] ローカルでの描画テスト（ペン、直線、四角、円、消しゴム）
- [ ] マップ移動・ズーム時の描画位置確認
- [ ] レイヤー機能の動作確認（追加、削除、表示切替、ロック）
- [ ] Undo/Redo動作確認
- [ ] 自動保存とリロード後のデータ復元確認
- [ ] Firebase Storageへのタイルアップロード確認

## Notes

- Firebase Storageを有効化し、`firebase deploy --only storage` でルールをデプロイする必要があります
- 既存の `drawings` コレクションのデータは保持されます（後方互換性のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)